### PR TITLE
Design/64 메인페이지 카테고리 그리드 컴포넌트 구현

### DIFF
--- a/src/components/Carousel/Carousel.jsx
+++ b/src/components/Carousel/Carousel.jsx
@@ -34,7 +34,7 @@ const Slide = styled(Box)({
 const NavigationButton = styled(IconButton)(({ theme }) => ({
   position: 'absolute',
   backgroundColor: 'rgba(255, 255, 255, 0.8)',
-  padding: '12px',
+  padding: '10px',
   '&:hover': {
     backgroundColor: 'rgba(255, 255, 255, 0.9)',
   },

--- a/src/components/Layout/BottomNav.jsx
+++ b/src/components/Layout/BottomNav.jsx
@@ -63,7 +63,7 @@ const StyledBottomNavigation = styled(BottomNavigation)`
 
   .MuiBottomNavigationAction-root {
     min-width: 60px;
-    padding: 6px 12px;
+    padding: 0px 0px;
     color: #666;
     transition: all 0.2s ease-in-out;
 

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -51,7 +51,7 @@ const StyledToolbar = styled(Toolbar)`
 const NavButton = styled(Button)`
   color: #666;
   border-radius: 8px;
-  padding: 6px 12px;
+  padding: 0px 0px;
   min-width: 60px;
   text-transform: none;
   font-size: 0.875rem;

--- a/src/components/Layout/MainLayout.jsx
+++ b/src/components/Layout/MainLayout.jsx
@@ -32,12 +32,12 @@ const MainContainer = styled(Box)`
 
 const ContentBox = styled(Box)`
   flex-grow: 1;
-  padding: 24px 16px;
+  padding: 0px;
   padding-bottom: 80px;
   margin-top: 64px;
 
   @media (min-width: 768px) and (max-width: 1024px) {
-    padding: 24px;
+    padding: 0px;
   }
 `;
 

--- a/src/components/news/NewsBox.jsx
+++ b/src/components/news/NewsBox.jsx
@@ -4,11 +4,9 @@ import { Box, Grid } from '@mui/material';
 import ArticleCard from '../article/ArticleCard';
 
 const Container = styled(Box)`
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  padding: 16px;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  padding: 0px;
+  margin-top: 16px;
+  margin-bottom: 16px;
   background-color: white;
   max-width: 1200px;
   min-width: 350px;
@@ -18,11 +16,8 @@ const Container = styled(Box)`
 
   @media (max-width: 350px) {
     min-width: 350px;
-    margin-left: -16px;
-    margin-right: -16px;
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
+    margin: 0;
+    padding: 8px 0;
   }
 `;
 
@@ -30,7 +25,8 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
+  padding: 0 0px;
 `;
 
 const TitleWrapper = styled.div`
@@ -65,11 +61,15 @@ const MoreButton = styled.button`
 
 const ArticlesContainer = styled.div`
   display: flex;
-  gap: 8px;
+  gap: 6px;
   
   .article-card {
     flex: 1;
     min-width: 0;
+  }
+
+  @media (max-width: 350px) {
+    gap: 2px;
   }
 `;
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -16,7 +16,7 @@ const ITEMS_PER_PAGE = 6;
 const StyledTab = styled(Tab)`
   color: #666;
   border-radius: 8px;
-  padding: 6px 12px;
+  padding: 0px 0px;
   min-width: 60px;
   text-transform: none;
   font-size: 0.875rem;
@@ -82,10 +82,9 @@ function HomePage() {
 
   return (
     <Container maxWidth="lg">
-      <Box sx={{ my: 4 }}>
-
+      <Box sx={{ my: 1 }}>
         {/* 카테고리 탭 */}
-        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 3 }}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 1 }}>
           <StyledTabs value={activeTab} onChange={handleTabChange} variant="scrollable" scrollButtons="auto" allowScrollButtonsMobile>
             {categories.map((cat) => (
               <StyledTab key={cat.value} label={cat.label} value={cat.value} />
@@ -93,17 +92,16 @@ function HomePage() {
           </StyledTabs>
         </Box>
 
-        {loading && ( <Box sx={{ display: 'flex', justifyContent: 'center', my: 5 }}><CircularProgress /></Box> )}
-        {error && ( <Alert severity="error" sx={{ my: 2 }}>{error}</Alert> )}
+        {loading && ( <Box sx={{ display: 'flex', justifyContent: 'center', my: 2 }}><CircularProgress /></Box> )}
+        {error && ( <Alert severity="error" sx={{ my: 1 }}>{error}</Alert> )}
         {!loading && !error && articles.length > 0 && (
-          <Box sx={{ mb: 4 }}>
+          <Box sx={{ mb: 2 }}>
             <Carousel 
               items={articles.map(article => (
                 <Box key={article.id} sx={{ width: '100%', height: '100%' }}>
                   <ArticleCard article={article} />
                 </Box>
               ))}
-              slidesPerView={1}
             />
           </Box>
         )}
@@ -125,7 +123,7 @@ function HomePage() {
         />
 
         {!loading && !error && totalPages > 1 && (
-           <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+           <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
              <Pagination count={totalPages} page={page} onChange={handlePageChange} color="primary" size="large" showFirstButton showLastButton />
            </Box>
          )}


### PR DESCRIPTION
## #️⃣연관된 이슈

#59 
#60 
#64   

## 📝작업 내용

> 메인 그리드 박스의 테두리를 제거하였습니다.
> 전체 페이지에 패딩 마진을 최대한 제거하여 화면을 최대한 채우게 수정하였습니다.

### 스크린샷
<img width="525" alt="image" src="https://github.com/user-attachments/assets/5cef1f6a-14bd-4abe-bd93-967bd268b03b" />


## 💬리뷰 요구사항(선택)
-
