### PR TITLE
Design/61 댓글 컴포넌트 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,6 @@ function App() {
   return (
     <ThemeProviderWrapper>
       <Router />
-      <BottomNav /> {/* 렌더링 확인 */}
     </ThemeProviderWrapper>
   );
 }

--- a/src/components/Layout/NoHeaderLayout.jsx
+++ b/src/components/Layout/NoHeaderLayout.jsx
@@ -1,0 +1,55 @@
+// src/components/Layout/MainLayout.jsx
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import { Box, Toolbar } from '@mui/material';
+import Header from './Header';
+import BottomNav from './BottomNav';
+import styled from '@emotion/styled';
+
+const MainContainer = styled(Box)`
+  max-width: 430px;
+  margin: 0 auto;
+  width: 100%;
+  min-height: 100vh;
+  position: relative;
+  border-radius: 24px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+  background-color: white;
+  overflow: hidden;
+
+  @media (min-width: 768px) and (max-width: 1024px) {
+    max-width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  @media (max-width: 767px) {
+    max-width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+  }
+`;
+
+const ContentBox = styled(Box)`
+  flex-grow: 1;
+  padding: 0px;
+  padding-bottom: 80px;
+  margin-top: 10px;
+
+  @media (min-width: 768px) and (max-width: 1024px) {
+    padding: 0px;
+  }
+`;
+
+function MainLayout() {
+  return (
+    <MainContainer>
+      <ContentBox component="main">
+        <Outlet />
+      </ContentBox>
+      <BottomNav />
+    </MainContainer>
+  );
+}
+
+export default MainLayout;

--- a/src/components/comments/CommentItem.jsx
+++ b/src/components/comments/CommentItem.jsx
@@ -1,41 +1,165 @@
 // src/components/comments/CommentItem.jsx
-import React from 'react';
-import { ListItem, ListItemAvatar, Avatar, ListItemText, Typography, Box, IconButton, Button, Link } from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
-import ReplyIcon from '@mui/icons-material/Reply';
+import React, { useState } from 'react';
+import { ListItem, ListItemAvatar, Avatar, ListItemText, Typography, Box, IconButton, Menu, MenuItem } from '@mui/material';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import FavoriteIcon from '@mui/icons-material/Favorite';
 
-function CommentItem({ comment, onDelete, onReply, level }) {
-  const formatDateTime = (dateString) => { /* ... 이전과 동일 ... */
-    try { return new Date(dateString).toLocaleString('ko-KR', { dateStyle: 'short', timeStyle: 'short' }); } catch (e) { return dateString; }
+function CommentItem({ comment, onDelete, onReply, level, isAuthor = false }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [isLiked, setIsLiked] = useState(false);
+  const open = Boolean(anchorEl);
+
+  const formatDateTime = (dateString) => {
+    try {
+      return new Date(dateString).toLocaleString('ko-KR', { dateStyle: 'short', timeStyle: 'short' });
+    } catch (e) {
+      return dateString;
+    }
   };
-  const handleDeleteClick = () => { if (onDelete) onDelete(comment.id); };
-  const handleReplyClick = () => { if (onReply) onReply(comment.id); };
+
+  const handleMoreClick = (event) => {
+    if (isAuthor) {
+      setAnchorEl(event.currentTarget);
+    }
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleDeleteClick = () => {
+    handleClose();
+    if (onDelete) onDelete(comment.id);
+  };
+
+  const handleReplyClick = () => {
+    if (onReply) onReply(comment.id);
+  };
+
+  const handleLikeClick = () => {
+    setIsLiked(!isLiked);
+  };
 
   return (
-    <ListItem alignItems="flex-start" divider sx={{ pl: level * 3, bgcolor: level > 0 ? `rgba(0, 0, 0, ${level * 0.03})` : 'inherit' }}>
+    <ListItem
+      alignItems="flex-start"
+      sx={{
+        pl: level * 3,
+        bgcolor: level > 0 ? `rgba(0, 0, 0, ${level * 0.03})` : 'inherit',
+        py: 1,
+      }}
+    >
       <ListItemAvatar sx={{ minWidth: '45px' }}>
-        <Avatar sx={{ width: 30, height: 30 }} alt={comment.author} src={`https://api.dicebear.com/8.x/initials/svg?seed=${comment.author}`} />
+        <Avatar
+          sx={{ width: 30, height: 30 }}
+          alt={comment.author}
+          src={`https://api.dicebear.com/8.x/initials/svg?seed=${comment.author}`}
+        />
       </ListItemAvatar>
       <ListItemText
-        primary={ <Typography component="span" variant="body2" color="text.primary" sx={{ fontWeight: 'bold' }}>{comment.author}</Typography> }
-        secondaryTypographyProps={{ component: 'div' }} // ★ 중요: p > div 오류 방지
+        primary={
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography component="span" variant="body2" color="text.primary" sx={{ fontWeight: 'bold' }}>
+              {comment.author}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {formatDateTime(comment.createdAt)}
+            </Typography>
+          </Box>
+        }
+        secondaryTypographyProps={{ component: 'div' }}
         secondary={
           <React.Fragment>
-            <Typography component="span" variant="body2" color="text.primary" sx={{ display: 'block', whiteSpace: 'pre-wrap', wordBreak: 'break-word', mb: 0.5 }}>
+            <Typography
+              component="span"
+              variant="body2"
+              color="text.primary"
+              sx={{ display: 'block', whiteSpace: 'pre-wrap', wordBreak: 'break-word', mb: 0.5 }}
+            >
               {comment.content}
             </Typography>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 0.5 }}>
-              <Typography variant="caption" color="text.secondary">{formatDateTime(comment.createdAt)}</Typography>
-              {onReply && (
-                <Link component="button" variant="caption" onClick={handleReplyClick} sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
-                  <ReplyIcon sx={{ fontSize: '1rem', mr: 0.3 }} /> 답글 달기
-                </Link>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mt: 1 }}>
+              <Box 
+                sx={{ 
+                  display: 'flex', 
+                  alignItems: 'center', 
+                  gap: 0.5, 
+                  cursor: 'pointer',
+                  bgcolor: 'rgba(0, 0, 0, 0.05)',
+                  borderRadius: '16px',
+                  padding: '4px 8px',
+                  '&:hover': {
+                    bgcolor: 'rgba(0, 0, 0, 0.1)',
+                  }
+                }} 
+                onClick={handleLikeClick}
+              >
+                {isLiked ? (
+                  <FavoriteIcon sx={{ fontSize: '1rem', color: 'red' }} />
+                ) : (
+                  <FavoriteBorderIcon sx={{ fontSize: '1rem' }} />
+                )}
+                <Typography variant="caption" color="text.secondary">
+                  {10}
+                </Typography>
+              </Box>
+              {!level && (
+                <Box 
+                  sx={{ 
+                    display: 'flex', 
+                    alignItems: 'center', 
+                    gap: 0.5, 
+                    cursor: 'pointer',
+                    bgcolor: 'rgba(0, 0, 0, 0.05)',
+                    borderRadius: '16px',
+                    padding: '4px 8px',
+                    '&:hover': {
+                      bgcolor: 'rgba(0, 0, 0, 0.1)',
+                    }
+                  }} 
+                  onClick={handleReplyClick}
+                >
+                  <ChatBubbleOutlineIcon sx={{ fontSize: '1rem' }} />
+                  <Typography variant="caption" color="text.secondary">
+                    {4}
+                  </Typography>
+                </Box>
               )}
             </Box>
           </React.Fragment>
         }
       />
-      {onDelete && ( <IconButton edge="end" aria-label="delete" onClick={handleDeleteClick} size="small" sx={{ mt: 1 }}><DeleteIcon fontSize="small" /></IconButton> )}
+      {isAuthor && (
+        <>
+          <IconButton
+            edge="end"
+            aria-label="more"
+            onClick={handleMoreClick}
+            size="small"
+            sx={{ mt: 1 }}
+          >
+            <MoreVertIcon fontSize="small" />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={open}
+            onClose={handleClose}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+          >
+            <MenuItem onClick={handleClose}>수정</MenuItem>
+            <MenuItem onClick={handleDeleteClick}>삭제</MenuItem>
+          </Menu>
+        </>
+      )}
     </ListItem>
   );
 }

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    // localStorage에서 사용자 정보 불러오기
+    const savedUser = localStorage.getItem('user');
+    return savedUser ? JSON.parse(savedUser) : null;
+  });
+
+  const login = useCallback((userData) => {
+    setUser(userData);
+    localStorage.setItem('user', JSON.stringify(userData));
+  }, []);
+
+  const logout = useCallback(() => {
+    setUser(null);
+    localStorage.removeItem('user');
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+} 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,11 +4,14 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 import { BrowserRouter } from 'react-router-dom'; // BrowserRouter import
+import { AuthProvider } from './contexts/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter> {/* BrowserRouter 적용 */}
-      <App />
+      <AuthProvider>
+        <App />
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -1,108 +1,132 @@
 // src/pages/ArticlePage.jsx
-import React, { useState, useEffect, useCallback } from 'react';
-import { Typography, Container, Box, CircularProgress, Alert, Paper, Chip, Divider, Breadcrumbs, Link, Button, TextField } from '@mui/material'; // List 제거
-import { useParams, Link as RouterLink } from 'react-router-dom';
-import { fetchArticleById } from '../services/articleApi'; // fetchArticles 제거 가능
-import HomeIcon from '@mui/icons-material/Home';
-import NewspaperIcon from '@mui/icons-material/Newspaper';
-
-import RecursiveComment from '../components/comments/RecursiveComment';
-import CommentReplyForm from '../components/comments/CommentReplyForm';
-
-// --- 목업 댓글 데이터 ---
-const initialMockComments = (articleId) => [
-    { id: 'cmt001', articleId: articleId, author: '댓글러1', content: '정말 유익한 기사네요!', createdAt: '2025-04-15T11:00:00Z', parentId: null },
-    { id: 'cmt002', articleId: articleId, author: '궁금해요', content: '이 부분은 조금 더 설명이 필요할 것 같아요.\n다른 의견 있으신 분?', createdAt: '2025-04-15T11:30:00Z', parentId: null },
-    { id: 'cmt003', articleId: articleId, author: '개발자A', content: 'cmt001님 의견 감사합니다. 저도 그렇게 생각해요.', createdAt: '2025-04-15T11:35:00Z', parentId: 'cmt001' },
-    { id: 'cmt004', articleId: articleId, author: '지나가던B', content: '저는 cmt002님 의견에 동의합니다.', createdAt: '2025-04-15T11:40:00Z', parentId: 'cmt002' },
-    { id: 'cmt005', articleId: articleId, author: '댓글러1', content: '개발자A님 답글 감사합니다!', createdAt: '2025-04-15T11:45:00Z', parentId: 'cmt003' },
-];
-
+import React, { useState, useEffect } from 'react';
+import { Box, IconButton, Typography, CircularProgress, Alert } from '@mui/material';
+import { useParams, useNavigate, Link as RouterLink } from 'react-router-dom';
+import { fetchArticleById } from '../services/articleApi';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import ArticleCard from '../components/article/ArticleCard';
+import NewsBox from '../components/news/NewsBox';
 
 function ArticlePage() {
   const { articleId } = useParams();
+  const navigate = useNavigate();
   const [article, setArticle] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [comments, setComments] = useState([]);
-  const [replyingToCommentId, setReplyingToCommentId] = useState(null);
+  const [relatedArticles, setRelatedArticles] = useState([]);
 
-  // 기사 로드 Effect
   useEffect(() => {
-    if (articleId) {
-      const loadArticleDetail = async () => {
-        try { setLoading(true); setError(null); const data = await fetchArticleById(articleId); if (data) setArticle(data); else setError('Article not found.'); }
-        catch (err) { setError(err.message || 'An unknown error occurred'); }
-        finally { setLoading(false); }
-      };
-      loadArticleDetail();
-      // 기사 ID 변경 시 목업 댓글도 다시 설정 (실제로는 API 호출)
-      setComments(initialMockComments(articleId));
-    } else { setError('Invalid Article ID.'); setLoading(false); }
+    const loadArticle = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await fetchArticleById(articleId);
+        if (data) {
+          setArticle(data);
+          // 임시로 관련 기사도 같은 데이터 사용
+          setRelatedArticles([data, data, data]);
+        } else {
+          setError('Article not found.');
+        }
+      } catch (err) {
+        setError(err.message || 'An unknown error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+    loadArticle();
   }, [articleId]);
 
-  // 댓글 등록 핸들러
-  const handleCommentSubmit = useCallback(async (content, parentId) => {
-    if (!articleId) return;
-    console.log(`Submitting comment: "${content}" with parentId: ${parentId}`);
-    await new Promise(resolve => setTimeout(resolve, 500));
-    const newCommentObject = { id: `cmt${Date.now()}`, articleId: articleId, author: '나야나', content: content, createdAt: new Date().toISOString(), parentId: parentId };
-    setComments(prevComments => [newCommentObject, ...prevComments]);
-  }, [articleId]);
+  const handleBack = () => {
+    navigate(-1);
+  };
 
-  const handleReplyClick = useCallback((commentId) => { setReplyingToCommentId(prev => (prev === commentId ? null : commentId)); }, []);
-  const handleCancelReply = useCallback(() => { setReplyingToCommentId(null); }, []);
-  const handleCommentDelete = useCallback((commentId) => { console.log('Deleting comment:', commentId); setComments(prev => prev.filter(comment => comment.id !== commentId)); }, []);
+  const handleCommentClick = () => {
+    navigate(`/comment/${articleId}`);
+  };
 
-  const formatDateTime = (dateString) => { try { return new Date(dateString).toLocaleString('ko-KR'); } catch (e) { return dateString; } };
-
-  if (loading) { return <Container maxWidth="md" sx={{ display: 'flex', justifyContent: 'center', my: 5 }}><CircularProgress /></Container>; }
-  if (error) { return <Container maxWidth="md" sx={{ my: 4 }}><Alert severity="error">{error}</Alert><Button component={RouterLink} to="/" sx={{ mt: 2 }}>홈으로 돌아가기</Button></Container>; }
-  if (!article) { return <Container maxWidth="md" sx={{ my: 4 }}><Alert severity="warning">Article data is unavailable.</Alert></Container>; }
-
-  const topLevelComments = comments.filter(comment => comment.parentId === null);
-  const renderReplyForm = (parentId) => ( <CommentReplyForm parentId={parentId} onSubmit={handleCommentSubmit} onCancel={handleCancelReply} placeholder="답글을 입력하세요..." submitButtonText="답글 등록" /> );
+  if (loading) return <CircularProgress sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }} />;
+  if (error) return <Alert severity="error" sx={{ m: 2 }}>{error}</Alert>;
+  if (!article) return <Alert severity="warning" sx={{ m: 2 }}>Article not found</Alert>;
 
   return (
-    <Container maxWidth="md">
-      <Box sx={{ my: 4 }}>
-        {/* Breadcrumbs */}
-        <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 3 }}>
-          <Link component={RouterLink} underline="hover" color="inherit" to="/" sx={{ display: 'flex', alignItems: 'center' }}><HomeIcon sx={{ mr: 0.5 }} fontSize="inherit" />Home</Link>
-          <Typography color="text.primary" sx={{ display: 'flex', alignItems: 'center' }}><NewspaperIcon sx={{ mr: 0.5 }} fontSize="inherit" />Article</Typography>
-        </Breadcrumbs>
-
-        {/* 기사 헤더 정보 */}
-        <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
-          <Typography variant="h4" component="h1" gutterBottom>{article.title}</Typography>
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2, flexWrap: 'wrap', gap: 1 }}>
-            <Typography variant="subtitle1" color="text.secondary">출처: {article.source}</Typography>
-            <Typography variant="subtitle2" color="text.secondary">발행: {formatDateTime(article.publishedAt)}</Typography>
-          </Box>
-          {article.category && <Chip label={article.category} size="small" />}
-          {article.thumbnailUrl && ( <Box sx={{ my: 2, textAlign: 'center' }}><img src={article.thumbnailUrl} alt={article.title} style={{ maxWidth: '100%', height: 'auto', borderRadius: '4px' }}/></Box> )}
-           <Typography variant="body1" color="text.secondary" paragraph>{article.summary}</Typography>
-           {/* 액션 아이콘 등 */}
-        </Paper>
-        <Divider sx={{ my: 3 }} />
-        {/* 기사 본문 */}
-        <Box component="article" sx={{ lineHeight: 1.7, '& h3': { mt: 3, mb: 1 }, '& h4': { mt: 2, mb: 1 }, '& p': { mb: 2 }, '& img': { maxWidth: '100%', height: 'auto' } }} dangerouslySetInnerHTML={{ __html: article.content }} />
-        <Divider sx={{ my: 3 }} />
-
-        {/* 댓글 섹션 */}
-        <Box component="section" aria-labelledby="comment-section-title">
-          <Typography variant="h6" id="comment-section-title" gutterBottom>댓글 ({comments.length})</Typography>
-          <Box sx={{ mb: 3 }}><CommentReplyForm parentId={null} onSubmit={handleCommentSubmit} placeholder="댓글을 남겨보세요..." submitButtonText="댓글 등록" /></Box>
-          <Box>
-             {topLevelComments.length > 0 ? (
-                 topLevelComments.map(comment => ( <RecursiveComment key={comment.id} comment={comment} allComments={comments} onReply={handleReplyClick} onDelete={handleCommentDelete} level={0} replyingToCommentId={replyingToCommentId} renderReplyForm={renderReplyForm} /> ))
-             ) : ( <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', py: 3 }}>첫 댓글을 남겨주세요!</Typography> )}
-          </Box>
-        </Box>
-
-        <Button component={RouterLink} to="/" variant="outlined" sx={{ mt: 4 }}>목록으로</Button>
+    <Box sx={{ pb: 7 }}>
+      {/* 헤더 */}
+      <Box sx={{ 
+        position: 'sticky', 
+        top: 0, 
+        bgcolor: 'white', 
+        zIndex: 1,
+        borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+        px: 2,
+        py: 1,
+        display: 'flex',
+        alignItems: 'center'
+      }}>
+        <IconButton onClick={handleBack} edge="start">
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography 
+          variant="subtitle1" 
+          component="h1" 
+          sx={{ 
+            ml: 1,
+            flexGrow: 1,
+            fontWeight: 'bold',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+        >
+          {article.title}
+        </Typography>
       </Box>
-    </Container>
+
+      {/* 메인 기사 카드 */}
+      <Box sx={{ p: 2 }}>
+        <ArticleCard article={article} />
+      </Box>
+
+      {/* 작가 프로필 */}
+      <Box sx={{ px: 2, py: 1 }}>
+        <NewsBox
+          title="작가 컴포넌트"
+          date=""
+          articles={[]}
+          onMoreClick={() => {}}
+        />
+      </Box>
+
+      {/* 댓글 섹션 */}
+      <Box 
+        onClick={handleCommentClick}
+        sx={{ 
+          px: 2, 
+          py: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+          borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+          cursor: 'pointer'
+        }}
+      >
+        <ChatBubbleOutlineIcon sx={{ fontSize: '1.2rem', color: 'text.secondary' }} />
+        <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+          댓글 305개
+        </Typography>
+      </Box>
+
+      {/* 관련 뉴스 */}
+      <Box sx={{ p: 2 }}>
+        <NewsBox
+          title="관련 뉴스"
+          articles={relatedArticles}
+          onMoreClick={() => {}}
+        />
+      </Box>
+    </Box>
   );
 }
 

--- a/src/pages/CommentPage.jsx
+++ b/src/pages/CommentPage.jsx
@@ -1,0 +1,224 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Box, IconButton, Typography, CircularProgress, Alert, Link, TextField, Button } from '@mui/material';
+import { useParams, useNavigate, Link as RouterLink } from 'react-router-dom';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { useAuth } from '../contexts/AuthContext';
+import CommentItem from '../components/comments/CommentItem';
+
+// 목업 댓글 데이터
+const initialMockComments = (articleId) => [
+  { id: 'cmt001', articleId: articleId, author: '댓글러1', content: '정말 유익한 기사네요!', createdAt: '2025-04-15T11:00:00Z', parentId: null },
+  { id: 'cmt002', articleId: articleId, author: '궁금해요', content: '이 부분은 조금 더 설명이 필요할 것 같아요.\n다른 의견 있으신 분?', createdAt: '2025-04-15T11:30:00Z', parentId: null },
+  { id: 'cmt003', articleId: articleId, author: '개발자A', content: 'cmt001님 의견 감사합니다. 저도 그렇게 생각해요.', createdAt: '2025-04-15T11:35:00Z', parentId: 'cmt001' },
+  { id: 'cmt004', articleId: articleId, author: '지나가던B', content: '저는 cmt002님 의견에 동의합니다.', createdAt: '2025-04-15T11:40:00Z', parentId: 'cmt002' },
+  { id: 'cmt005', articleId: articleId, author: '댓글러1', content: '개발자A님 답글 감사합니다!', createdAt: '2025-04-15T11:45:00Z', parentId: 'cmt003' },
+];
+
+function CommentPage() {
+  const { articleId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [comments, setComments] = useState([]);
+  const [selectedCommentId, setSelectedCommentId] = useState(null);
+  const [showReplies, setShowReplies] = useState(false);
+  const [commentText, setCommentText] = useState('');
+
+  useEffect(() => {
+    // 목업 댓글 데이터 로드
+    setComments(initialMockComments(articleId));
+  }, [articleId]);
+
+  const handleBack = () => {
+    if (showReplies) {
+      setSelectedCommentId(null);
+      setShowReplies(false);
+    } else {
+      navigate(-1);
+    }
+  };
+
+  const handleCommentSubmit = useCallback(async () => {
+    if (!articleId || !user || !commentText.trim()) return;
+    
+    const newCommentObject = {
+      id: `cmt${Date.now()}`,
+      articleId: articleId,
+      author: user.name,
+      content: commentText.trim(),
+      createdAt: new Date().toISOString(),
+      parentId: selectedCommentId
+    };
+    
+    setComments(prevComments => [newCommentObject, ...prevComments]);
+    setCommentText('');
+  }, [articleId, user, commentText, selectedCommentId]);
+
+  const handleCommentDelete = useCallback((commentId) => {
+    console.log('Deleting comment:', commentId);
+    setComments(prev => prev.filter(comment => comment.id !== commentId));
+  }, []);
+
+  const handleViewReplies = useCallback((commentId) => {
+    setSelectedCommentId(commentId);
+    setShowReplies(true);
+  }, []);
+
+  const selectedComment = selectedCommentId ? comments.find(c => c.id === selectedCommentId) : null;
+  const replies = selectedCommentId ? comments.filter(c => c.parentId === selectedCommentId) : [];
+  const topLevelComments = comments.filter(comment => comment.parentId === null);
+
+  return (
+    <Box 
+      sx={{ 
+        maxWidth: '430px',
+        margin: '0 auto',
+        height: '100vh',
+        position: 'relative',
+        bgcolor: 'white',
+        boxShadow: '0px 0px 10px rgba(0, 0, 0, 0.1)',
+        overflow: 'hidden'
+      }}
+    >
+      {/* 헤더 */}
+      <Box sx={{ 
+        position: 'sticky', 
+        top: 0, 
+        bgcolor: 'white', 
+        zIndex: 1,
+        borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+        px: 2,
+        py: 1,
+        display: 'flex',
+        alignItems: 'center'
+      }}>
+        <IconButton onClick={handleBack} edge="start">
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography 
+          variant="subtitle1" 
+          component="h1" 
+          sx={{ 
+            ml: 1,
+            flexGrow: 1,
+            fontWeight: 'bold'
+          }}
+        >
+          {showReplies ? '답글' : `댓글 ${comments.length}개`}
+        </Typography>
+      </Box>
+
+      {/* 댓글 목록 */}
+      <Box sx={{ flex: 1, overflow: 'auto', pb: user ? 7 : 0 }}>
+        {!showReplies ? (
+          topLevelComments.map(comment => (
+            <Box key={comment.id} sx={{ px: 2 }}>
+              <CommentItem
+                comment={comment}
+                onReply={() => handleViewReplies(comment.id)}
+                onDelete={handleCommentDelete}
+                level={0}
+                isAuthor={user && comment.author === user.name}
+              />
+            </Box>
+          ))
+        ) : (
+          <>
+            {selectedComment && (
+              <>
+                <Box sx={{ px: 2 }}>
+                  <CommentItem
+                    comment={selectedComment}
+                    level={0}
+                    isAuthor={user && selectedComment.author === user.name}
+                    onDelete={handleCommentDelete}
+                  />
+                </Box>
+                {replies.map(reply => (
+                  <Box key={reply.id} sx={{ pl: 4, pr: 2 }}>
+                    <CommentItem
+                      comment={reply}
+                      level={1}
+                      isAuthor={user && reply.author === user.name}
+                      onDelete={handleCommentDelete}
+                    />
+                  </Box>
+                ))}
+              </>
+            )}
+          </>
+        )}
+      </Box>
+
+      {/* 댓글 입력 영역 */}
+      {user ? (
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            bgcolor: 'white',
+            borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+            p: 2,
+            display: 'flex',
+            gap: 1
+          }}
+        >
+          <TextField
+            fullWidth
+            size="small"
+            placeholder={showReplies ? "답글을 입력하세요..." : "댓글을 입력하세요..."}
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                borderRadius: '20px',
+              }
+            }}
+          />
+          <Button
+            variant="contained"
+            onClick={handleCommentSubmit}
+            disabled={!commentText.trim()}
+            sx={{
+              minWidth: 'auto',
+              px: 2,
+              borderRadius: '20px'
+            }}
+          >
+            등록
+          </Button>
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            bgcolor: 'rgba(232, 245, 253, 0.95)',
+            borderTop: '1px solid rgba(0, 0, 0, 0.12)',
+          }}
+        >
+          <Alert 
+            severity="info" 
+            sx={{ 
+              py: 1.5,
+              '& .MuiAlert-message': {
+                width: '100%',
+                textAlign: 'center'
+              },
+              '& .MuiAlert-icon': {
+                display: 'none'
+              }
+            }}
+          >
+            댓글을 작성하려면 <Link component={RouterLink} to="/login">로그인</Link>이 필요합니다.
+          </Alert>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export default CommentPage; 

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -3,8 +3,10 @@
 import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import MainLayout                from '../components/Layout/MainLayout';
+import NoHeaderLayout            from '../components/Layout/NoHeaderLayout';
 import HomePage                  from '../pages/HomePage';
 import ArticlePage               from '../pages/ArticlePage';
+import CommentPage               from '../pages/CommentPage';
 import LoginPage                 from '../pages/LoginPage';
 import GoogleRedirectHandler     from '../pages/GoogleRedirectHandler';
 
@@ -14,12 +16,16 @@ function Router() {
       {/* 레이아웃 없이 렌더링할 페이지들 */}
       <Route path="/login" element={<LoginPage />} />
       <Route path="/oauth/google/redirect" element={<GoogleRedirectHandler />} />
+      <Route path="/comment/:articleId" element={<CommentPage />} />
 
       {/* MainLayout: 헤더/푸터 있는 공통 레이아웃 */}
       <Route element={<MainLayout />}>
         <Route path="/"                   element={<HomePage />} />
-        <Route path="/article/:articleId" element={<ArticlePage />} />
         {/* 필요하면 추가 페이지 */}
+      </Route>
+
+      <Route element={<NoHeaderLayout />}>
+        <Route path="/article/:articleId" element={<ArticlePage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #15 
> #61 
> #56 

## 📝작업 내용

> 댓글 컴포넌트 구축 및 페이지 구축
> 전체 레이아웃 수정(페이지에 헤더 포함 여부, 바텀Nav바 포함 여부)
> 로그인 시 사용할 수 서비스 구분하는 기능 추가

### 스크린샷
기사 상세 페이지
<img width="449" alt="image" src="https://github.com/user-attachments/assets/8eb1a33e-5f69-4456-a7dc-25f57994b7d9" />


댓글 페이지
<img width="492" alt="image" src="https://github.com/user-attachments/assets/b5b5e425-f8f1-42a5-95e4-9744d357cd4b" />

답글 페이지
<img width="401" alt="image" src="https://github.com/user-attachments/assets/c3dbf672-15c0-4197-bba5-452ee90be954" />


## 💬리뷰 요구사항(선택)

