### PR TITLE
design: 작가 컴포넌트 구현(#63)

### DIFF
--- a/src/components/AuthorCard.jsx
+++ b/src/components/AuthorCard.jsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import ShareIcon from '@mui/icons-material/Share';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import { Box, IconButton, Typography, Avatar, Collapse } from '@mui/material';
+
+function AuthorCard({ author, viewCount }) {
+  const [showOriginalArticle, setShowOriginalArticle] = useState(false);
+
+  const handleShare = () => {
+    navigator.clipboard.writeText(window.location.href);
+    alert('URL이 복사되었습니다!');
+  };
+
+  const toggleOriginalArticle = () => {
+    setShowOriginalArticle(!showOriginalArticle);
+  };
+
+  return (
+    <Box sx={{ p: 2, borderTop: '1px solid rgba(0, 0, 0, 0.12)', borderBottom: '1px solid rgba(0, 0, 0, 0.12)' }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Avatar src={author?.image} alt={author?.name} />
+          <Box>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+              {author?.name}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {viewCount}명 읽는 중
+            </Typography>
+          </Box>
+        </Box>
+        
+        {/* 액션 버튼들을 오른쪽으로 이동 */}
+        <Box sx={{ display: 'flex', gap: 0.5 }}>
+          <IconButton 
+            onClick={handleShare}
+            size="small"
+            sx={{ 
+              bgcolor: 'action.hover',
+              '&:hover': { bgcolor: 'action.selected' }
+            }}
+          >
+            <ShareIcon fontSize="small" />
+          </IconButton>
+          <IconButton 
+            size="small"
+            sx={{ 
+              bgcolor: 'action.hover',
+              '&:hover': { bgcolor: 'action.selected' }
+            }}
+          >
+            <FavoriteBorderIcon fontSize="small" />
+          </IconButton>
+          <IconButton 
+            size="small"
+            sx={{ 
+              bgcolor: 'action.hover',
+              '&:hover': { bgcolor: 'action.selected' }
+            }}
+          >
+            <BookmarkBorderIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </Box>
+
+      {/* 원본 기사 보기 버튼 */}
+      <Box 
+        onClick={toggleOriginalArticle}
+        sx={{ 
+          mt: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: 'pointer',
+          py: 1
+        }}
+      >
+        <Typography 
+          variant="body2" 
+          sx={{ 
+            color: 'text.primary',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5
+          }}
+        >
+          원본 기사 보기
+          {showOriginalArticle ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+        </Typography>
+      </Box>
+
+      {/* 확장되는 원본 기사 섹션 */}
+      <Collapse in={showOriginalArticle}>
+        <Box sx={{ py: 1.5, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          <Typography 
+            component="a" 
+            href="#"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ 
+              color: 'primary.main',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+              fontSize: '0.875rem'
+            }}
+          >
+            • 펜데믹 이후 GPU 가격 폭등, AI 붐으로 수요 더욱 증가 - 테크뉴스
+          </Typography>
+          <Typography 
+            component="a" 
+            href="#"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ 
+              color: 'primary.main',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+              fontSize: '0.875rem'
+            }}
+          >
+            • GPU 수급난 해결될까? NVIDIA 신제품 출시 예정 - IT저널
+          </Typography>
+          <Typography 
+            component="a" 
+            href="#"
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{ 
+              color: 'primary.main',
+              textDecoration: 'none',
+              '&:hover': { textDecoration: 'underline' },
+              fontSize: '0.875rem'
+            }}
+          >
+            • 반도체 업계, GPU 생산량 확대 계획 발표 - 경제일보
+          </Typography>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+export default AuthorCard; 

--- a/src/components/Layout/NoHeaderLayout.jsx
+++ b/src/components/Layout/NoHeaderLayout.jsx
@@ -33,7 +33,6 @@ const MainContainer = styled(Box)`
 const ContentBox = styled(Box)`
   flex-grow: 1;
   padding: 0px;
-  padding-bottom: 80px;
   margin-top: 10px;
 
   @media (min-width: 768px) and (max-width: 1024px) {

--- a/src/components/author/AuthorCard.jsx
+++ b/src/components/author/AuthorCard.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Box, Avatar, Typography } from '@mui/material';
+import styled from '@emotion/styled';
+
+const AuthorContainer = styled(Box)`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 16px;
+  background: white;
+`;
+
+const AuthorInfo = styled(Box)`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const AuthorAvatar = styled(Avatar)`
+  width: 40px;
+  height: 40px;
+`;
+
+const TextContainer = styled(Box)`
+  display: flex;
+  flex-direction: column;
+`;
+
+const AuthorName = styled(Typography)`
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #000;
+`;
+
+const ViewCount = styled(Typography)`
+  font-size: 0.8rem;
+  color: #666;
+`;
+
+const AuthorCard = ({ author, viewCount }) => {
+  const formatViewCount = (count) => {
+    if (count >= 10000) {
+      return `${(count / 10000).toFixed(1)}만명 보는 중`;
+    }
+    return `${count}명 보는 중`;
+  };
+
+  return (
+    <AuthorContainer>
+      <AuthorInfo>
+        <AuthorAvatar
+          alt={author.name}
+          src={author.imageUrl || `https://api.dicebear.com/8.x/initials/svg?seed=${author.name}`}
+        />
+        <TextContainer>
+          <AuthorName>{author.name}</AuthorName>
+          <ViewCount>{formatViewCount(viewCount)}</ViewCount>
+        </TextContainer>
+      </AuthorInfo>
+    </AuthorContainer>
+  );
+};
+
+export default AuthorCard; 

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -1,12 +1,13 @@
 // src/pages/ArticlePage.jsx
 import React, { useState, useEffect } from 'react';
 import { Box, IconButton, Typography, CircularProgress, Alert } from '@mui/material';
-import { useParams, useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { fetchArticleById } from '../services/articleApi';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import ArticleCard from '../components/article/ArticleCard';
 import NewsBox from '../components/news/NewsBox';
+import AuthorCard from '../components/AuthorCard';
 
 function ArticlePage() {
   const { articleId } = useParams();
@@ -89,14 +90,13 @@ function ArticlePage() {
       </Box>
 
       {/* 작가 프로필 */}
-      <Box sx={{ px: 2, py: 1 }}>
-        <NewsBox
-          title="작가 컴포넌트"
-          date=""
-          articles={[]}
-          onMoreClick={() => {}}
-        />
-      </Box>
+      <AuthorCard 
+        author={{
+          name: article.author || "작성자",
+          image: article.authorImage || "/placeholder-author.jpg"
+        }}
+        viewCount={23}
+      />
 
       {/* 댓글 섹션 */}
       <Box 
@@ -107,8 +107,6 @@ function ArticlePage() {
           display: 'flex',
           alignItems: 'center',
           gap: 1,
-          borderTop: '1px solid rgba(0, 0, 0, 0.12)',
-          borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
           cursor: 'pointer'
         }}
       >


### PR DESCRIPTION
상세페이지에 들어가는 작가 컴포넌트를 구현하였습니다.

## #️⃣연관된 이슈

#63 

## 📝작업 내용

상세페이지에 들어가는 작가 컴포넌트를 구현하였습니다.

### 스크린샷

<img width="447" alt="image" src="https://github.com/user-attachments/assets/6c17e50e-eef9-4541-82b1-d6ad54c2dea9" />


## 💬리뷰 요구사항(선택)
