### PR TITLE
feat: 카테고리 페이지 api 연동(#71)

### DIFF
--- a/public/api/v1/webtoons/data.json
+++ b/public/api/v1/webtoons/data.json
@@ -6,32 +6,32 @@
         {
           "id": 101,
           "title": "엔비디아 루빈 출시",
-          "thumbnailUrl": "https://cdn.example.com/webtoons/101.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/01.jpg"
         },
         {
           "id": 102,
           "title": "초거대 모델과 미래 예측",
-          "thumbnailUrl": "https://cdn.example.com/webtoons/102.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/02.jpg"
         },
         {
           "id": 103,
           "title": "생성형 AI가 바꾸는 일상",
-          "thumbnailUrl": "https://cdn.example.com/webtoons/103.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/03.jpg"
         },
         {
           "id": 104,
           "title": "오픈AI의 차세대 언어 모델",
-          "thumbnailUrl": "https://cdn.example.com/webtoons/104.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/04.jpg"
         },
         {
           "id": 105,
           "title": "구글 vs 엔비디아: AI 칩 전쟁",
-          "thumbnailUrl": "https://cdn.example.com/webtoons/105.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/05.jpg"
         },
         {
           "id": 106,
           "title": "디지털 휴먼의 부상",
-          "thumbnailUrl": "https://cdn.example.com/webtoons/106.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/06.jpg"
         }
       ],
       "pageInfo": {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #71 

## 📝작업 내용

> 카테고리 페이지 API 연동했지만 진짜 api 요청 경로인
> /api/v1/webtoons?category={category_id}는
> ?와 =은 public경로로 요청을 보내는 것에서는 구현할 수 없어 백엔드 api 완성시 수정 예정

### 스크린샷

<img width="545" alt="image" src="https://github.com/user-attachments/assets/9136341b-ce8b-4c94-b206-157fda5e203c" />
