### PR TITLE
feat: 웹툰 상세 페이지 API 연동

### DIFF
--- a/public/api/v1/webtoons/101/data.json
+++ b/public/api/v1/webtoons/101/data.json
@@ -6,28 +6,28 @@
       "slides": [
         {
           "slide_seq": 0,
-          "imageUrl": "https://cdn.example.com/101/0.jpg",
-          "text": "슬라이드 설명1"
+          "imageUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/01.jpg",
+          "text": "웹툰 제목"
         },
         {
           "slide_seq": 1,
-          "imageUrl": "https://cdn.example.com/101/1.jpg",
-          "text": "슬라이드 설명2"
+          "imageUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/02.jpg",
+          "text": "슬라이드 설명1"
         },
         {
           "slide_seq": 2,
-          "imageUrl": "https://cdn.example.com/101/2.jpg",
-          "text": "슬라이드 설명3"
+          "imageUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/03.jpg",
+          "text": "슬라이드 설명2"
         },
         {
           "slide_seq": 3,
-          "imageUrl": "https://cdn.example.com/101/3.jpg",
-          "text": "슬라이드 설명4"
+          "imageUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/04.jpg",
+          "text": "슬라이드 설명3"
         },
         {
           "slide_seq": 4,
-          "imageUrl": "https://cdn.example.com/101/4.jpg",
-          "text": "슬라이드 설명5"
+          "imageUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/05.jpg",
+          "text": "슬라이드 설명4"
         }
       ],
       "author": {

--- a/public/api/v1/webtoons/101/details/data.json
+++ b/public/api/v1/webtoons/101/details/data.json
@@ -16,22 +16,22 @@
         {
           "id": 2001,
           "title": "AI 칩셋 시장 전망, 엔비디아 독주 계속될까?",
-          "thumbnailUrl": "https://cdn.example.com/news/related/2001.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/01.jpg"
         },
         {
           "id": 2002,
           "title": "GPU 성능 비교: 루빈 vs 호퍼",
-          "thumbnailUrl": "https://cdn.example.com/news/related/2002.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/02.jpg"
         },
         {
           "id": 2003,
           "title": "TSMC와 엔비디아, 3nm 파운드리 협력 발표",
-          "thumbnailUrl": "https://cdn.example.com/news/related/2003.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/03.jpg"
         },
         {
           "id": 2004,
           "title": "루빈 GPU, 게임 성능은 얼마나 나올까?",
-          "thumbnailUrl": "https://cdn.example.com/news/related/2004.jpg"
+          "thumbnailUrl": "https://sinsa-image.s3.ap-northeast-2.amazonaws.com/04.jpg"
         }
       ],
       "createdAt": "2024-04-17T12:00:00Z",

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -1,42 +1,68 @@
 // src/pages/ArticlePage.jsx
 import React, { useState, useEffect } from 'react';
-import { Box, IconButton, Typography, CircularProgress, Alert } from '@mui/material';
-import { useParams, useNavigate } from 'react-router-dom';
-import { fetchArticleById } from '../services/articleApi';
+import { Box, IconButton, Typography, CircularProgress, Alert, Avatar, Collapse } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import { useParams, useNavigate } from 'react-router-dom';
+import Carousel from '../components/Carousel/Carousel';
 import ArticleCard from '../components/article/ArticleCard';
 import NewsBox from '../components/grid/MainGrid';
 import AuthorCard from '../components/author/AuthorCard';
+import FavoriteIcon from '@mui/icons-material/Favorite';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import BookmarkIcon from '@mui/icons-material/Bookmark';
+import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
+import ShareIcon from '@mui/icons-material/Share';
+import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import DefaultAxios from '../api/DefaultAxios';
 
 function ArticlePage() {
   const { articleId } = useParams();
   const navigate = useNavigate();
-  const [article, setArticle] = useState(null);
+  const [slides, setSlides] = useState([]);
+  const [author, setAuthor] = useState(null);
+  const [isLiked, setIsLiked] = useState(false);
+  const [isBookmarked, setIsBookmarked] = useState(false);
+  const [likeCount, setLikeCount] = useState(0);
+  const [sourceNews, setSourceNews] = useState([]);
+  const [commentCount, setCommentCount] = useState(0);
+  const [relatedNews, setRelatedNews] = useState([]);
+  const [title, setTitle] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [relatedArticles, setRelatedArticles] = useState([]);
+  const [showOriginal, setShowOriginal] = useState(false);
+  const [viewCount, setViewCount] = useState(0);
 
   useEffect(() => {
-    const loadArticle = async () => {
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
       try {
-        setLoading(true);
-        setError(null);
-        const data = await fetchArticleById(articleId);
-        if (data) {
-          setArticle(data);
-          // 임시로 관련 기사도 같은 데이터 사용
-          setRelatedArticles([data, data, data]);
-        } else {
-          setError('Article not found.');
-        }
+        // 기본 정보
+        const res1 = await DefaultAxios.get(`/api/v1/webtoons/${articleId}/data.json`);
+        const data1 = res1.data?.data;
+        setSlides(data1?.slides || []);
+        setAuthor(data1?.author || null);
+        setIsLiked(!!data1?.isLiked);
+        setIsBookmarked(!!data1?.isBookmarked);
+        setLikeCount(data1?.likeCount || 0);
+        setTitle(data1?.slides?.[0]?.text || '');
+        setViewCount(data1?.viewCount || 0);
+
+        // 상세 정보
+        const res2 = await DefaultAxios.get(`/api/v1/webtoons/${articleId}/details/data.json`);
+        const data2 = res2.data?.data;
+        setSourceNews(data2?.sourceNews || []);
+        setCommentCount(data2?.commentCount || 0);
+        setRelatedNews((data2?.relatedNews || []).slice(0, 3));
       } catch (err) {
         setError(err.message || 'An unknown error occurred');
       } finally {
         setLoading(false);
       }
     };
-    loadArticle();
+    fetchData();
   }, [articleId]);
 
   const handleBack = () => {
@@ -47,9 +73,21 @@ function ArticlePage() {
     navigate(`/comment/${articleId}`);
   };
 
+  const handleLike = () => {
+    setIsLiked((prev) => !prev);
+    setLikeCount((prev) => (isLiked ? prev - 1 : prev + 1));
+  };
+
+  const handleBookmark = () => {
+    setIsBookmarked((prev) => !prev);
+  };
+
+  const toggleOriginal = () => {
+    setShowOriginal((prev) => !prev);
+  };
+
   if (loading) return <CircularProgress sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }} />;
   if (error) return <Alert severity="error" sx={{ m: 2 }}>{error}</Alert>;
-  if (!article) return <Alert severity="warning" sx={{ m: 2 }}>Article not found</Alert>;
 
   return (
     <Box sx={{ pb: 7 }}>
@@ -80,23 +118,76 @@ function ArticlePage() {
             whiteSpace: 'nowrap'
           }}
         >
-          {article.title}
+          {title}
         </Typography>
       </Box>
 
-      {/* 메인 기사 카드 */}
-      <Box sx={{ p: 2 }}>
-        <ArticleCard article={article} />
+      {/* 캐러셀 1:1 비율 */}
+      <Box sx={{ p: 2, pt: 3 }}>
+        <Carousel
+          items={slides.map((slide) => (
+            <Box key={slide.slide_seq} sx={{ width: '100%', aspectRatio: '1/1', position: 'relative', borderRadius: 2, overflow: 'hidden' }}>
+              <img src={slide.imageUrl} alt={slide.text} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+              <Box sx={{ position: 'absolute', left: 0, bottom: 0, width: '100%', bgcolor: 'rgba(0,0,0,0.4)', color: 'white', p: 1, fontSize: 14 }}>{slide.text}</Box>
+            </Box>
+          ))}
+        />
       </Box>
 
-      {/* 작가 프로필 */}
-      <AuthorCard 
-        author={{
-          name: article.author || "작성자",
-          image: article.authorImage || "/placeholder-author.jpg"
-        }}
-        viewCount={23}
-      />
+      {/* 작가 프로필 + 액션 버튼 한 줄 배치 */}
+      <Box sx={{ px: 2, mt: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        {/* 왼쪽: 작가 */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Avatar src={author?.profileImageUrl} alt={author?.name} sx={{ width: 40, height: 40 }} />
+          <Box>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{author?.name}</Typography>
+            <Typography variant="caption" color="text.secondary">조회수 {viewCount}회</Typography>
+          </Box>
+        </Box>
+        {/* 오른쪽: 액션 버튼 (공유, 하트, 북마크 한 줄, 그 아래 좋아요 수) */}
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.5, mt: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <IconButton><ShareIcon /></IconButton>
+            <IconButton onClick={handleLike} color={isLiked ? 'error' : 'default'} sx={{ p: 0.5 }}>
+              {isLiked ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+            </IconButton>
+            <IconButton onClick={handleBookmark} sx={{ color: 'black' }}>
+              {isBookmarked ? <BookmarkIcon /> : <BookmarkBorderIcon />}
+            </IconButton>
+          </Box>
+          <Box>
+            <Typography variant="body2" sx={{ fontSize: 15, mt: -2.0 }}>{likeCount}</Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      {/* 원본 기사 보기 (접기/펼치기) */}
+      <Box sx={{ px: 2, mt: 2 }}>
+        <Box onClick={toggleOriginal} sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer', userSelect: 'none', mb: 1 }}>
+          <Typography variant="subtitle2" sx={{ fontWeight: 600, mr: 0.5, display: 'flex', alignItems: 'center' }}>
+            원본 기사 보기
+            <IconButton size="small" sx={{ p: 0.3, ml: 0, verticalAlign: 'middle' }}>
+              {showOriginal ? <ArrowDropUpIcon fontSize="small" /> : <ArrowDropDownIcon fontSize="small" />}
+            </IconButton>
+          </Typography>
+        </Box>
+        <Collapse in={showOriginal}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, pl: 0 }}>
+            {sourceNews.map((news, idx) => (
+              <Typography
+                key={idx}
+                component="a"
+                href={news.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ color: 'primary.main', textDecoration: 'none', display: 'block', fontSize: '1rem', '&:hover': { textDecoration: 'underline' } }}
+              >
+                {news.title}
+              </Typography>
+            ))}
+          </Box>
+        </Collapse>
+      </Box>
 
       {/* 댓글 섹션 */}
       <Box 
@@ -112,7 +203,7 @@ function ArticlePage() {
       >
         <ChatBubbleOutlineIcon sx={{ fontSize: '1.2rem', color: 'text.secondary' }} />
         <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          댓글 305개
+          댓글 {commentCount}개
         </Typography>
       </Box>
 
@@ -120,7 +211,12 @@ function ArticlePage() {
       <Box sx={{ p: 2 }}>
         <NewsBox
           title="관련 뉴스"
-          articles={relatedArticles}
+          articles={relatedNews.map(news => ({
+            id: news.id,
+            title: news.title,
+            thumbnailUrl: news.thumbnailUrl,
+            viewCount: 0,
+          }))}
           onMoreClick={() => {}}
         />
       </Box>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -99,8 +99,11 @@ function HomePage() {
           {/* 카테고리 탭 */}
           <CategoryTabs activeTab={activeTab} onTabChange={handleTabChange} />
 
+          {/* 로딩 중일 때 로딩 스피너 표시 */}
           {loading && ( <Box sx={{ display: 'flex', justifyContent: 'center', my: 2 }}><CircularProgress /></Box> )}
           {error && ( <Alert severity="error" sx={{ my: 1 }}>{error}</Alert> )}
+          
+          {/* 최상위 3개 웹툰 캐러셀 표시 */}
           {!loading && !error && top3Data.topToons && top3Data.topToons.length > 0 && (
             <Box sx={{ mb: 2 }}>
               <Carousel 
@@ -167,6 +170,7 @@ function HomePage() {
             />
           ))}
 
+          {/* 페이지네이션 표시 */} 
           {!loading && !error && totalPages > 1 && (
              <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
                <Pagination count={totalPages} page={page} onChange={handlePageChange} color="primary" size="large" showFirstButton showLastButton />


### PR DESCRIPTION
## #️⃣연관된 이슈

#28 #29 #30 

## 📝작업 내용

> 상세페이지 API 연동

### 스크린샷

<img width="463" alt="image" src="https://github.com/user-attachments/assets/bd519349-b380-42a6-a7c4-92de068aa349" />

### 추가 구현할 내용

캐러셀을 메인페이지에 사용했던 컴포넌트로 하여 자동으로 넘어가게 되는데 넘어가지 않는 것으로 수정 예정
