### PR TITLE
[#115] 유저 정보 수정 페이지 수정 및 QA 수정부분 추가 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2177,7 +2177,6 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -101,14 +101,14 @@ function Header() {
   const navigate = useNavigate();
   const { user } = useAuth();
 
-  // 프로필 이미지(1순위: localStorage, 2순위: user.picture, 3순위: user.profileImage)
+  // 프로필 이미지(1순위: localStorage의 user, 2순위: user.picture)
   let profileImg = '';
   let nickname = '';
 
   try {
-    const userInfoStr = localStorage.getItem('userInfo');
-    if (userInfoStr) {
-      const parsed = JSON.parse(userInfoStr);
+    const userStr = localStorage.getItem('user');
+    if (userStr) {
+      const parsed = JSON.parse(userStr);
       profileImg = parsed.profileImageUrl || '';
       nickname = parsed.nickname || '';
     }
@@ -155,7 +155,7 @@ function Header() {
             {user && profileImg ? (
               <Avatar
                 src={profileImg}
-                alt={user?.name || '프로필'}
+                alt={nickname || '프로필'}
                 sx={{
                   width: 32,
                   height: 32,

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -103,14 +103,17 @@ function Header() {
 
   // 프로필 이미지(1순위: localStorage, 2순위: user.picture, 3순위: user.profileImage)
   let profileImg = '';
+  let nickname = '';
+
   try {
-    profileImg =
-      localStorage.getItem('profileImage') ||
-      user?.picture ||
-      user?.profileImage ||
-      '';
+    const userInfoStr = localStorage.getItem('userInfo');
+    if (userInfoStr) {
+      const parsed = JSON.parse(userInfoStr);
+      profileImg = parsed.profileImageUrl || '';
+      nickname = parsed.nickname || '';
+    }
   } catch (e) {
-    profileImg = user?.picture || user?.profileImage || '';
+    profileImg = '';
   }
 
   const handleUserIconClick = () => {

--- a/src/components/Layout/NoHeaderLayout.jsx
+++ b/src/components/Layout/NoHeaderLayout.jsx
@@ -1,8 +1,7 @@
-// src/components/Layout/MainLayout.jsx
+// src/components/Layout/NoHeaderLayout.jsx
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import { Box, Toolbar } from '@mui/material';
-import Header from './Header';
+import { Box } from '@mui/material';
 import BottomNav from './BottomNav';
 import styled from '@emotion/styled';
 
@@ -40,7 +39,7 @@ const ContentBox = styled(Box)`
   }
 `;
 
-function MainLayout() {
+function NoHeaderLayout() {
   return (
     <MainContainer>
       <ContentBox component="main">
@@ -51,4 +50,4 @@ function MainLayout() {
   );
 }
 
-export default MainLayout;
+export default NoHeaderLayout;

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -72,9 +72,17 @@ function EditProfilePage() {
       };
 
       const response = await TokenAxios.patch('/api/v1/users/me', body);
-
       const updated = response.data.data;
-      localStorage.setItem('user', JSON.stringify(updated));
+
+      const prev = JSON.parse(localStorage.getItem('user') || '{}');
+
+      const merged = {
+        ...prev,
+        ...updated, // nickname, profileImageUrl 덮어쓰기 (email 유지됨)
+      };
+
+      localStorage.setItem('user', JSON.stringify(merged));
+
       setSuccessModalOpen(true);
       setTimeout(() => {
         setSuccessModalOpen(false);

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -16,7 +16,7 @@ function EditProfilePage() {
   const fileInputRef = useRef();
 
   useEffect(() => {
-    const userInfo = localStorage.getItem('userInfo');
+    const userInfo = localStorage.getItem('user');
     if (userInfo) {
       const parsed = JSON.parse(userInfo);
       setNickname(parsed.nickname || '');
@@ -53,7 +53,7 @@ function EditProfilePage() {
       const response = await TokenAxios.patch('/api/v1/users/me', body);
 
       const updated = response.data.data;
-      localStorage.setItem('userInfo', JSON.stringify(updated));
+      localStorage.setItem('user', JSON.stringify(updated));
       setSuccessModalOpen(true);
       setTimeout(() => {
         setSuccessModalOpen(false);

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -13,6 +13,8 @@ function EditProfilePage() {
   const [profileImg, setProfileImg] = useState('');
   const [open, setOpen] = useState(false);
   const [successModalOpen, setSuccessModalOpen] = useState(false);
+  const [nicknameError, setNicknameError] = useState('');
+  const [emptyNicknameModalOpen, setEmptyNicknameModalOpen] = useState(false);
   const fileInputRef = useRef();
 
   useEffect(() => {
@@ -43,7 +45,26 @@ function EditProfilePage() {
 
   const handleClearNickname = () => setNickname('');
 
+  const handleNicknameChange = (e) => {
+    const value = e.target.value;
+    if (value.length > 16) {
+      setNicknameError('닉네임은 16자 이상 불가능합니다');
+      return;
+    }
+    setNicknameError('');
+    setNickname(value);
+  };
+
   const handleSave = async () => {
+    if (!nickname.trim()) {
+      setEmptyNicknameModalOpen(true);
+      setTimeout(() => {
+        setEmptyNicknameModalOpen(false);
+        navigate(-1);
+      }, 2000);
+      return;
+    }
+
     try {
       const body = {
         nickname: nickname,
@@ -94,8 +115,10 @@ function EditProfilePage() {
         <TextField
           fullWidth
           value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
+          onChange={handleNicknameChange}
           placeholder="닉네임"
+          error={!!nicknameError}
+          helperText={nicknameError}
           InputProps={{
             endAdornment: nickname && (
               <InputAdornment position="end">
@@ -134,6 +157,15 @@ function EditProfilePage() {
           <Box component="img" src={logoutLogo} alt="완료" sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }} />
           <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center' }}>
             회원정보가<br />수정되었습니다!
+          </Typography>
+        </Box>
+      </Modal>
+
+      <Modal open={emptyNicknameModalOpen}>
+        <Box sx={{ position: 'absolute', top: '40%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, width: 320, height: 320, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', outline: 'none' }}>
+          <Box component="img" src={logoutLogo} alt="완료" sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }} />
+          <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center' }}>
+            닉네임을 입력하지 않으시면<br />기존 닉네임을 사용합니다!
           </Typography>
         </Box>
       </Modal>

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -16,7 +16,7 @@ function EditProfilePage() {
   const fileInputRef = useRef();
 
   useEffect(() => {
-    const userInfo = localStorage.getItem('user');
+    const userInfo = localStorage.getItem('userInfo');
     if (userInfo) {
       const parsed = JSON.parse(userInfo);
       setNickname(parsed.nickname || '');
@@ -45,11 +45,15 @@ function EditProfilePage() {
 
   const handleSave = async () => {
     try {
-      const response = await TokenAxios.patch('/api/v1/users/me', {
+      const body = {
         nickname: nickname,
-        profileimage: profileImg,
-      });
-      localStorage.setItem('user', JSON.stringify(response.data.data));
+        profileImage: profileImg,
+      };
+
+      const response = await TokenAxios.patch('/api/v1/users/me', body);
+
+      const updated = response.data.data;
+      localStorage.setItem('userInfo', JSON.stringify(updated));
       setSuccessModalOpen(true);
       setTimeout(() => {
         setSuccessModalOpen(false);
@@ -114,7 +118,6 @@ function EditProfilePage() {
         </Button>
       </Box>
 
-      {/* 회원탈퇴 안내 모달 */}
       <Modal open={open} onClose={handleCloseModal}>
         <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, p: 4, width: 320, minHeight: 200, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <Typography sx={{ fontWeight: 600, fontSize: 18, mb: 2 }}>
@@ -126,12 +129,11 @@ function EditProfilePage() {
         </Box>
       </Modal>
 
-      {/* 저장 완료 안내 모달 */}
       <Modal open={successModalOpen}>
-        <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, p: 4, width: 320, minHeight: 320, display: 'flex', flexDirection: 'column', alignItems: 'center', outline: 'none' }}>
+        <Box sx={{ position: 'absolute', top: '40%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, width: 320, height: 320, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', outline: 'none' }}>
           <Box component="img" src={logoutLogo} alt="완료" sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }} />
-          <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center', mt: 5 }}>
-            회원정보가  수정되었습니다!
+          <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center' }}>
+            회원정보가<br />수정되었습니다!
           </Typography>
         </Box>
       </Modal>

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -5,12 +5,14 @@ import CloseIcon from '@mui/icons-material/Close';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { useNavigate } from 'react-router-dom';
 import TokenAxios from '../api/TokenAxios';
+import logoutLogo from '../assets/logout_logo.jpeg';
 
 function EditProfilePage() {
   const navigate = useNavigate();
   const [nickname, setNickname] = useState('');
   const [profileImg, setProfileImg] = useState('');
   const [open, setOpen] = useState(false);
+  const [successModalOpen, setSuccessModalOpen] = useState(false);
   const fileInputRef = useRef();
 
   useEffect(() => {
@@ -18,7 +20,7 @@ function EditProfilePage() {
     if (userInfo) {
       const parsed = JSON.parse(userInfo);
       setNickname(parsed.nickname || '');
-      setProfileImg(parsed.profileImageUrl || '');
+      setProfileImg(parsed.profileImageUrl || '/default-profile.png');
     } else {
       navigate('/login', { replace: true });
     }
@@ -47,9 +49,12 @@ function EditProfilePage() {
         nickname: nickname,
         profileimage: profileImg,
       });
-      alert('저장되었습니다.');
       localStorage.setItem('user', JSON.stringify(response.data.data));
-      navigate(-1);
+      setSuccessModalOpen(true);
+      setTimeout(() => {
+        setSuccessModalOpen(false);
+        navigate(-1);
+      }, 2000);
     } catch (e) {
       alert('저장 실패');
     }
@@ -109,6 +114,7 @@ function EditProfilePage() {
         </Button>
       </Box>
 
+      {/* 회원탈퇴 안내 모달 */}
       <Modal open={open} onClose={handleCloseModal}>
         <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, p: 4, width: 320, minHeight: 200, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <Typography sx={{ fontWeight: 600, fontSize: 18, mb: 2 }}>
@@ -117,6 +123,16 @@ function EditProfilePage() {
           <Button onClick={handleCloseModal} variant="contained" sx={{ bgcolor: '#111', color: '#fff', borderRadius: 2, fontWeight: 600 }}>
             확인
           </Button>
+        </Box>
+      </Modal>
+
+      {/* 저장 완료 안내 모달 */}
+      <Modal open={successModalOpen}>
+        <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, p: 4, width: 320, minHeight: 320, display: 'flex', flexDirection: 'column', alignItems: 'center', outline: 'none' }}>
+          <Box component="img" src={logoutLogo} alt="완료" sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }} />
+          <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center', mt: 5 }}>
+            회원정보가  수정되었습니다!
+          </Typography>
         </Box>
       </Modal>
     </Box>

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -58,10 +58,11 @@ function EditProfilePage() {
   const handleSave = async () => {
     if (!nickname.trim()) {
       setEmptyNicknameModalOpen(true);
-      setTimeout(() => {
-        setEmptyNicknameModalOpen(false);
-        navigate(-1);
-      }, 2000);
+      return;
+    }
+
+    if (nickname.trim().length < 2) {
+      setNicknameError('닉네임은 2~16자로 설정해주세요');
       return;
     }
 
@@ -78,7 +79,7 @@ function EditProfilePage() {
 
       const merged = {
         ...prev,
-        ...updated, // nickname, profileImageUrl 덮어쓰기 (email 유지됨)
+        ...updated,
       };
 
       localStorage.setItem('user', JSON.stringify(merged));
@@ -169,12 +170,19 @@ function EditProfilePage() {
         </Box>
       </Modal>
 
-      <Modal open={emptyNicknameModalOpen}>
+      <Modal open={emptyNicknameModalOpen} onClose={() => setEmptyNicknameModalOpen(false)}>
         <Box sx={{ position: 'absolute', top: '40%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, width: 320, height: 320, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', outline: 'none' }}>
-          <Box component="img" src={logoutLogo} alt="완료" sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }} />
+          <Box component="img" src={logoutLogo} alt="경고" sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }} />
           <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center' }}>
-            닉네임을 입력하지 않으시면<br />기존 닉네임을 사용합니다!
+            잘못된 닉네임입니다.<br />닉네임은 2~16자로 설정해주세요
           </Typography>
+          <Button
+            onClick={() => setEmptyNicknameModalOpen(false)}
+            variant="contained"
+            sx={{ mt: 3, bgcolor: '#111', color: '#fff', borderRadius: 2, fontWeight: 600 }}
+          >
+            확인
+          </Button>
         </Box>
       </Modal>
     </Box>

--- a/src/pages/EditProfilePage.jsx
+++ b/src/pages/EditProfilePage.jsx
@@ -1,0 +1,126 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Box, Typography, Button, Avatar, IconButton, TextField, Modal, InputAdornment } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
+import AddCircleIcon from '@mui/icons-material/AddCircle';
+import { useNavigate } from 'react-router-dom';
+import TokenAxios from '../api/TokenAxios';
+
+function EditProfilePage() {
+  const navigate = useNavigate();
+  const [nickname, setNickname] = useState('');
+  const [profileImg, setProfileImg] = useState('');
+  const [open, setOpen] = useState(false);
+  const fileInputRef = useRef();
+
+  useEffect(() => {
+    const userInfo = localStorage.getItem('user');
+    if (userInfo) {
+      const parsed = JSON.parse(userInfo);
+      setNickname(parsed.nickname || '');
+      setProfileImg(parsed.profileImageUrl || '');
+    } else {
+      navigate('/login', { replace: true });
+    }
+  }, [navigate]);
+
+  const handleAvatarClick = () => {
+    fileInputRef.current.click();
+  };
+
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const imageDataUrl = ev.target.result;
+      setProfileImg(imageDataUrl);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleClearNickname = () => setNickname('');
+
+  const handleSave = async () => {
+    try {
+      const response = await TokenAxios.patch('/api/v1/users/me', {
+        nickname: nickname,
+        profileimage: profileImg,
+      });
+      alert('저장되었습니다.');
+      localStorage.setItem('user', JSON.stringify(response.data.data));
+      navigate(-1);
+    } catch (e) {
+      alert('저장 실패');
+    }
+  };
+
+  const handleOpenWithdrawModal = () => setOpen(true);
+  const handleCloseModal = () => setOpen(false);
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: '#fff', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <Box sx={{ width: '100%', display: 'flex', alignItems: 'center', position: 'relative', height: 60, mb: 2, borderBottom: '1px solid #eee' }}>
+        <IconButton onClick={() => navigate(-1)} sx={{ position: 'absolute', left: 10, top: '50%', transform: 'translateY(-50%)' }}>
+          <ArrowBackIcon />
+        </IconButton>
+        <Typography variant="h6" sx={{ width: '100%', textAlign: 'center', fontWeight: 'bold', fontSize: 18, letterSpacing: 1 }}>
+          회원정보 수정
+        </Typography>
+      </Box>
+
+      <input type="file" accept="image/*" style={{ display: 'none' }} ref={fileInputRef} onChange={handleFileChange} />
+      <Box sx={{ position: 'relative', mt: 2 }}>
+        <Avatar
+          src={profileImg || '/default-profile.png'}
+          alt="프로필 이미지"
+          sx={{ width: 100, height: 100, border: '2px solid #eee', boxShadow: '0 2px 8px rgba(0,0,0,0.06)', cursor: 'pointer' }}
+          onClick={handleAvatarClick}
+        />
+        <AddCircleIcon sx={{ position: 'absolute', right: -4, bottom: -4, color: '#888', fontSize: 28 }} />
+      </Box>
+
+      <Box sx={{ width: '100%', maxWidth: 320, mt: 4 }}>
+        <Typography sx={{ fontWeight: 500, mb: 1 }}>닉네임을 입력해주세요</Typography>
+        <TextField
+          fullWidth
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          placeholder="닉네임"
+          InputProps={{
+            endAdornment: nickname && (
+              <InputAdornment position="end">
+                <IconButton onClick={handleClearNickname}>
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Typography variant="caption" sx={{ mt: 0.5, textAlign: 'right', display: 'block', color: '#888' }}>{nickname.length}/16</Typography>
+      </Box>
+
+      <Box sx={{ width: '100%', maxWidth: 320, mt: 4 }}>
+        <Button fullWidth variant="contained" onClick={handleSave} sx={{ bgcolor: '#111', color: '#fff', fontWeight: 600, borderRadius: 2 }}>
+          회원정보 저장
+        </Button>
+        <Button fullWidth variant="outlined" onClick={handleOpenWithdrawModal} sx={{ mt: 2, borderColor: '#111', color: '#111', fontWeight: 600, borderRadius: 2 }}>
+          회원탈퇴
+        </Button>
+      </Box>
+
+      <Modal open={open} onClose={handleCloseModal}>
+        <Box sx={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, p: 4, width: 320, minHeight: 200, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <Typography sx={{ fontWeight: 600, fontSize: 18, mb: 2 }}>
+            해당 기능은 곧 추가될 예정입니다!
+          </Typography>
+          <Button onClick={handleCloseModal} variant="contained" sx={{ bgcolor: '#111', color: '#fff', borderRadius: 2, fontWeight: 600 }}>
+            확인
+          </Button>
+        </Box>
+      </Modal>
+    </Box>
+  );
+}
+
+export default EditProfilePage;

--- a/src/pages/GoogleRedirectHandler.jsx
+++ b/src/pages/GoogleRedirectHandler.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import DefaultAxios from '../api/DefaultAxios';
+import TokenAxios from '../api/TokenAxios';
 
 function GoogleRedirectHandler() {
   const navigate = useNavigate();
@@ -13,23 +14,85 @@ function GoogleRedirectHandler() {
         const urlParams = new URLSearchParams(window.location.search);
         const code = urlParams.get('code');
 
-        if (!code) throw new Error('인증 코드를 받지 못했습니다.');
+        if (!code) throw new Error('구글 인증 코드를 받지 못했습니다.');
 
+        // 1️⃣ 구글 인증 코드로 토큰 요청
         const response = await DefaultAxios.post(
           import.meta.env.VITE_GOOGLE_CALLBACK_API_URL,
-          { code }
+          {
+            code,
+            provider: 'GOOGLE'
+          }
         );
 
-        const data = response.data;
+        console.log('구글 로그인 응답:', response.data);
 
-        localStorage.setItem('userInfo', JSON.stringify(data.userInfo));
-        localStorage.setItem('accessToken', data.accessToken);
-        localStorage.setItem('refreshToken', data.refreshToken);
+        // 2️⃣ 응답 데이터 구조 확인 및 처리
+        const { accessToken, refreshToken, user } = response.data;
 
-        login(data.userInfo);
+        if (!accessToken || !refreshToken) {
+          throw new Error('토큰 정보가 없습니다.');
+        }
+
+        // 3️⃣ 토큰 저장
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
+
+        // 4️⃣ TokenAxios에 토큰 설정
+        TokenAxios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+        // 5️⃣ 사용자 정보 처리
+        if (user) {
+          // 서버에서 사용자 정보를 받은 경우
+          // 이미 가입된 사용자인 경우 기존 정보 유지
+          const existingUser = localStorage.getItem('user');
+          if (existingUser) {
+            const parsedUser = JSON.parse(existingUser);
+            if (parsedUser.email === user.email) {
+              // 이메일이 일치하는 경우 기존 사용자 정보 사용
+              login(parsedUser);
+            } else {
+              // 새로운 사용자인 경우 서버에서 받은 정보 사용
+              localStorage.setItem('user', JSON.stringify(user));
+              login(user);
+            }
+          } else {
+            // 로컬 스토리지에 사용자 정보가 없는 경우
+            localStorage.setItem('user', JSON.stringify(user));
+            login(user);
+          }
+        } else {
+          // 사용자 정보를 별도로 요청해야 하는 경우
+          try {
+            const userRes = await TokenAxios.get('/api/v1/users/profile');
+            const userData = userRes.data.data;
+
+            // 이미 가입된 사용자인 경우 기존 정보 유지
+            const existingUser = localStorage.getItem('user');
+            if (existingUser) {
+              const parsedUser = JSON.parse(existingUser);
+              if (parsedUser.email === userData.email) {
+                login(parsedUser);
+              } else {
+                localStorage.setItem('user', JSON.stringify(userData));
+                login(userData);
+              }
+            } else {
+              localStorage.setItem('user', JSON.stringify(userData));
+              login(userData);
+            }
+          } catch (profileError) {
+            console.error('사용자 프로필 조회 실패:', profileError);
+            throw new Error('사용자 정보를 가져오는데 실패했습니다.');
+          }
+        }
+
         navigate('/');
       } catch (error) {
         console.error('구글 로그인 처리 중 오류:', error);
+        if (error.response) {
+          console.error('서버 응답:', error.response.data);
+        }
         navigate('/login');
       }
     };

--- a/src/pages/KakaoRedirectHandler.jsx
+++ b/src/pages/KakaoRedirectHandler.jsx
@@ -39,7 +39,7 @@ function KakaoRedirectHandler() {
         login(user); // Context 업데이트
 
         // ✅ userInfo는 이제 사용하지 않음
-        localStorage.removeItem('userInfo');
+        //localStorage.removeItem('userInfo');
 
         navigate('/');
       } catch (error) {

--- a/src/pages/KakaoRedirectHandler.jsx
+++ b/src/pages/KakaoRedirectHandler.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import DefaultAxios from '../api/DefaultAxios';
+import TokenAxios from '../api/TokenAxios';
 
 function KakaoRedirectHandler() {
   const navigate = useNavigate();
@@ -20,13 +21,26 @@ function KakaoRedirectHandler() {
           { code }
         );
 
-        const data = response.data;
+        const { accessToken, refreshToken } = response.data;
 
-        localStorage.setItem('userInfo', JSON.stringify(data.userInfo));
-        localStorage.setItem('accessToken', data.accessToken);
-        localStorage.setItem('refreshToken', data.refreshToken);
+        // 1️⃣ 토큰 저장
+        localStorage.setItem('accessToken', accessToken);
+        localStorage.setItem('refreshToken', refreshToken);
 
-        login(data.userInfo);
+        // 2️⃣ TokenAxios에 토큰 설정
+        TokenAxios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+
+        // 3️⃣ 서버에서 사용자 프로필 받아오기
+        const userRes = await TokenAxios.get('/api/v1/users/profile');
+        const user = userRes.data.data;
+
+        // 4️⃣ user 저장 (nickname 포함됨)
+        localStorage.setItem('user', JSON.stringify(user));
+        login(user); // Context 업데이트
+
+        // ✅ userInfo는 이제 사용하지 않음
+        localStorage.removeItem('userInfo');
+
         navigate('/');
       } catch (error) {
         console.error('카카오 로그인 처리 중 오류:', error);

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -12,7 +12,7 @@ function MyProfilePage() {
   const fileInputRef = useRef();
 
   useEffect(() => {
-    const userStr = localStorage.getItem('userInfo');
+    const userStr = localStorage.getItem('user');
     if (userStr) {
       const userObj = JSON.parse(userStr);
       setUser(userObj);

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -26,7 +26,7 @@ function MyProfilePage() {
   }, [navigate]);
 
   const handleEdit = () => {
-    alert('회원정보 수정 기능은 준비중입니다.');
+    navigate('/edit-profile');
   };
 
   const handleAvatarClick = () => {

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -12,16 +12,13 @@ function MyProfilePage() {
   const fileInputRef = useRef();
 
   useEffect(() => {
-    const userInfo = localStorage.getItem('userInfo');
-    if (userInfo) {
-      setUser(JSON.parse(userInfo));
+    const userStr = localStorage.getItem('userInfo');
+    if (userStr) {
+      const userObj = JSON.parse(userStr);
+      setUser(userObj);
+      setProfileImg(userObj.profileImageUrl || '');
     } else {
       navigate('/login', { replace: true });
-    }
-
-    const localImg = localStorage.getItem('profileImage');
-    if (localImg) {
-      setProfileImg(localImg);
     }
   }, [navigate]);
 
@@ -29,41 +26,17 @@ function MyProfilePage() {
     navigate('/edit-profile');
   };
 
-  const handleAvatarClick = () => {
-    fileInputRef.current.click();
-  };
-
-  const handleFileChange = (e) => {
-    const file = e.target.files[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = (ev) => {
-      const imageDataUrl = ev.target.result;
-      setProfileImg(imageDataUrl);
-      localStorage.setItem('profileImage', imageDataUrl);
-    };
-    reader.readAsDataURL(file);
-  };
-
   const handleLogoutClick = () => setOpen(true);
 
   const handleLogout = () => {
     setOpen(false);
-    localStorage.clear();
+    sessionStorage.clear();
     localStorage.removeItem('profileImage');
     localStorage.removeItem('user');
     navigate('/');
   };
 
   const handleCancel = () => setOpen(false);
-
-  // 🔽 최종 프로필 이미지 선택 로직
-  const resolvedProfileImage =
-    profileImg ||
-    user?.profileImage ||
-    user?.picture ||
-    '/default-profile.png';
 
   return (
     <Box sx={{ minHeight: '100vh', bgcolor: '#fff', display: 'flex', flexDirection: 'column', alignItems: 'center', pt: 0 }}>
@@ -76,23 +49,21 @@ function MyProfilePage() {
         </Typography>
       </Box>
 
-      <input type="file" accept="image/*" style={{ display: 'none' }} ref={fileInputRef} onChange={handleFileChange} />
       <Avatar
-        src={resolvedProfileImage}
-        alt={user?.name || '프로필'}
+        src={profileImg}
+        alt={user?.nickname || '프로필'}
         sx={{
           width: 100,
           height: 100,
           margin: '24px auto 0 auto',
           border: '2px solid #eee',
           boxShadow: '0 2px 8px rgba(0,0,0,0.06)',
-          cursor: 'pointer',
+          cursor: 'default',
         }}
-        onClick={handleAvatarClick}
       />
 
       <Typography variant="h6" sx={{ mt: 3, mb: 0.5, fontWeight: 600, textAlign: 'center' }}>
-        {user?.name || '이름 없음'}
+        {user?.nickname || '이름 없음'}
       </Typography>
       <Typography variant="body2" sx={{ color: '#888', mb: 3, textAlign: 'center' }}>
         {user?.email || '이메일 없음'}

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -12,6 +12,7 @@ import MyProfilePage from '../pages/MyProfilePage';
 import GoogleRedirectHandler from '../pages/GoogleRedirectHandler';
 import KakaoRedirectHandler from '../pages/KakaoRedirectHandler';
 import RecentPage from '../pages/RecentPage';
+import EditProfilePage from '../pages/EditProfilePage';
 
 function Router() {
   return (
@@ -36,7 +37,7 @@ function Router() {
 
 
       <Route element={<NoHeaderLayout />}>
-        
+        <Route path="/edit-profile" element={<EditProfilePage />} />
         <Route path="/recent" element={<RecentPage />} />
       </Route>
     </Routes>

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -24,19 +24,15 @@ function Router() {
       <Route path="/oauth2/callback/kakao" element={<KakaoRedirectHandler />} />
       <Route path='/comment/:articleId' element={<CommentPage />} />
 
-      {/* ⭐️ 기존 헤더/바텀네비 없는 단독 페이지로 분리 ⭐️ */}
-      <Route path="/users/profile" element={<MyProfilePage />} />
-
-   
       {/* MainLayout: 헤더/푸터 있는 공통 레이아웃 */}
       <Route element={<MainLayout />}>
         <Route path="/" element={<HomePage />} />
         <Route path="/category/:category_id" element={<CategoryPage />} />
-        <Route path='/article/:articleId' element={<ArticlePage />}/>
+        <Route path='/article/:articleId' element={<ArticlePage />} />
       </Route>
 
-
       <Route element={<NoHeaderLayout />}>
+        <Route path="/users/profile" element={<MyProfilePage />} />
         <Route path="/edit-profile" element={<EditProfilePage />} />
         <Route path="/recent" element={<RecentPage />} />
       </Route>

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -19,10 +19,12 @@ function Router() {
     <Routes>
       {/* 여기에 LoginPage 연결 */}
       {/* <Route path="/login" element={<GoogleRedirectHandler />} /> */}
-      <Route path="/login" element={<LoginPage />} />
       <Route path="/oauth2/callback/google" element={<GoogleRedirectHandler />} />
       <Route path="/oauth2/callback/kakao" element={<KakaoRedirectHandler />} />
       <Route path='/comment/:articleId' element={<CommentPage />} />
+
+      {/* ⭐️ 기존 헤더/바텀네비 없는 단독 페이지로 분리 ⭐️ */}
+
 
       {/* MainLayout: 헤더/푸터 있는 공통 레이아웃 */}
       <Route element={<MainLayout />}>
@@ -32,9 +34,10 @@ function Router() {
       </Route>
 
       <Route element={<NoHeaderLayout />}>
-        <Route path="/users/profile" element={<MyProfilePage />} />
         <Route path="/edit-profile" element={<EditProfilePage />} />
         <Route path="/recent" element={<RecentPage />} />
+        <Route path="/users/profile" element={<MyProfilePage />} />
+        <Route path="/login" element={<LoginPage />} />
       </Route>
     </Routes>
   );

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,5 @@
+// src/utils/auth.js
+export function isLoggedIn() {
+    return !!localStorage.getItem('access_token');
+  }
+  


### PR DESCRIPTION
## #️⃣연관된 이슈

#115  및 QA (https://www.notion.so/1ee1f8c56a9580c2b18ed8997a029426?v=421cd1095ba748f2ae5f15b832778b67)

## 📝작업 내용
유저 프로필 이미지, 닉네임을 변경할 수 있도록 페이지 추가
백엔드와 api 연동하였습니다.
QA 레이아웃 통일하였습니다.

### 스크린샷
1. 레이아웃 통일 
![image](https://github.com/user-attachments/assets/7b6cb9c3-96b4-40bd-9bb2-b439c1ab2462)

![image](https://github.com/user-attachments/assets/75a91dc8-bc90-403e-9097-72c89109678e)

2. 회원정보수정페이지
![image](https://github.com/user-attachments/assets/e14eaf31-5566-4366-acd3-416ea802e48e)


- 닉네임 최대 16자 이상 불가능하도록 설정
 
![image](https://github.com/user-attachments/assets/0c5b4285-680b-485a-bc22-027a61aac9b9)

- 닉네임 빈칸으로 저장할 시 경고 모달 추가
![image](https://github.com/user-attachments/assets/a83eea0f-0181-439e-9fd9-e5a1411efe2a)



-수정완료 창
![image](https://github.com/user-attachments/assets/7a53443f-2aec-40ae-ac62-e08a22defea6)



## 💬리뷰 요구사항(선택)
혹시 코드에 이상있는지 확인부탁드립니다..


감사합니다:)
