### PR TITLE
120 배포 후 qa 진행

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.2",
-        "sweetalert2": "^11.21.0"
+        "sweetalert2": "^11.21.0",
+        "zustand": "^5.0.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -4433,6 +4434,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
+      "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.2",
-    "sweetalert2": "^11.21.0"
+    "sweetalert2": "^11.21.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/src/components/Carousel/Carousel.jsx
+++ b/src/components/Carousel/Carousel.jsx
@@ -63,6 +63,9 @@ const Carousel = ({ items, autoSlide = false, autoSlideInterval = 5000 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const totalItems = items.length;
   const intervalRef = useRef(null);
+  // 터치 스와이프 상태
+  const touchStartX = useRef(null);
+  const touchEndX = useRef(null);
 
   const nextSlide = () => {
     setCurrentIndex((prevIndex) => (prevIndex + 1) % totalItems);
@@ -80,6 +83,26 @@ const Carousel = ({ items, autoSlide = false, autoSlideInterval = 5000 }) => {
   const handlePrevClick = () => {
     prevSlide();
     if (autoSlide) resetInterval();
+  };
+
+  // 터치 이벤트 핸들러
+  const onTouchStart = (e) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+  const onTouchMove = (e) => {
+    touchEndX.current = e.touches[0].clientX;
+  };
+  const onTouchEnd = () => {
+    if (touchStartX.current !== null && touchEndX.current !== null) {
+      const diff = touchStartX.current - touchEndX.current;
+      if (Math.abs(diff) > 40) { // 스와이프 최소 거리
+        if (diff > 0) nextSlide(); // 왼쪽으로 스와이프
+        else prevSlide(); // 오른쪽으로 스와이프
+        if (autoSlide) resetInterval();
+      }
+    }
+    touchStartX.current = null;
+    touchEndX.current = null;
   };
 
   // 자동 슬라이드 관리
@@ -114,7 +137,11 @@ const Carousel = ({ items, autoSlide = false, autoSlideInterval = 5000 }) => {
       >
         <ArrowBack />
       </NavigationButton>
-      <CarouselContainer>
+      <CarouselContainer
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+      >
         <SlideContainer>
           {items.map((item, index) => (
             <Slide

--- a/src/components/Carousel/Carousel.jsx
+++ b/src/components/Carousel/Carousel.jsx
@@ -49,8 +49,8 @@ const NavigationButton = styled(IconButton)(({ theme }) => ({
 
 const PageIndicator = styled(Box)({
   position: 'absolute',
-  bottom: '16px',
-  right: '16px',
+  top: '8px',
+  right: '8px',
   backgroundColor: 'rgba(0, 0, 0, 0.6)',
   color: 'white',
   padding: '4px 8px',
@@ -59,18 +59,10 @@ const PageIndicator = styled(Box)({
   fontSize: '14px',
 });
 
-const Carousel = ({ items }) => {
+const Carousel = ({ items, autoSlide = false, autoSlideInterval = 5000 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const totalItems = items.length;
-
-  const resetInterval = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-    intervalRef.current = setInterval(() => {
-      nextSlide();
-    }, 5000);
-  };
+  const intervalRef = useRef(null);
 
   const nextSlide = () => {
     setCurrentIndex((prevIndex) => (prevIndex + 1) % totalItems);
@@ -82,27 +74,36 @@ const Carousel = ({ items }) => {
 
   const handleNextClick = () => {
     nextSlide();
-    resetInterval();
+    if (autoSlide) resetInterval();
   };
 
   const handlePrevClick = () => {
     prevSlide();
-    resetInterval();
+    if (autoSlide) resetInterval();
   };
 
-  const intervalRef = useRef(null);
-
-  useEffect(() => {
+  // 자동 슬라이드 관리
+  const resetInterval = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
     intervalRef.current = setInterval(() => {
       nextSlide();
-    }, 5000);
+    }, autoSlideInterval);
+  };
 
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
-  }, []);
+  useEffect(() => {
+    if (autoSlide) {
+      intervalRef.current = setInterval(() => {
+        nextSlide();
+      }, autoSlideInterval);
+      return () => {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+        }
+      };
+    }
+  }, [autoSlide, autoSlideInterval, totalItems]);
 
   return (
     <CarouselWrapper>

--- a/src/components/Layout/ArticleLayout.jsx
+++ b/src/components/Layout/ArticleLayout.jsx
@@ -31,17 +31,18 @@ const MainContainer = styled(Box)`
 `;
 
 const ContentBox = styled(Box)`
+
   flex-grow: 1;
   padding: 0px;
   padding-bottom: 80px;
-  margin-top: 80px;
+  margin-top: 64px;
 
   @media (min-width: 768px) and (max-width: 1024px) {
     padding: 0px;
   }
 `;
 
-function MainLayout() {
+function ArticleLayout() {
   return (
     <MainContainer>
       <Header />
@@ -53,4 +54,4 @@ function MainLayout() {
   );
 }
 
-export default MainLayout;
+export default ArticleLayout;

--- a/src/components/Layout/BottomNav.jsx
+++ b/src/components/Layout/BottomNav.jsx
@@ -11,7 +11,8 @@ import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import PersonIcon from '@mui/icons-material/Person';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import styled from '@emotion/styled';
-import Swal from 'sweetalert2';
+import { showInfoSwal } from '../modal/ShowInfoModal';
+
 
 const StyledPaper = styled(Paper)`
   max-width: 430px;
@@ -126,12 +127,7 @@ function BottomNav() {
       setValue(newValue);
       navigate(newValue);
     } else {
-      Swal.fire({
-        icon: 'info',
-        title: '해당기능은 준비중입니다!',
-        confirmButtonColor: '#222',
-        confirmButtonText: '확인'
-      });
+      showInfoSwal();
     }
   };
 

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -129,6 +129,7 @@ function Header() {
     Swal.fire({
       icon: 'info',
       title: '해당기능은 준비중입니다!',
+      scrollbarPadding: false,
       confirmButtonColor: '#222',
       confirmButtonText: '확인'
     });

--- a/src/components/Layout/Header.jsx
+++ b/src/components/Layout/Header.jsx
@@ -7,7 +7,7 @@ import PersonOutlineOutlinedIcon from '@mui/icons-material/PersonOutlineOutlined
 import styled from '@emotion/styled';
 import logo from '../../assets/logo.png';
 import { useAuth } from '../../contexts/AuthContext';
-import Swal from 'sweetalert2';
+import { showInfoSwal } from '../modal/ShowInfoModal';
 
 const StyledAppBar = styled(AppBar)`
   max-width: 430px;
@@ -126,13 +126,7 @@ function Header() {
 
   const handleNotificationClick = (e) => {
     e.preventDefault();
-    Swal.fire({
-      icon: 'info',
-      title: '해당기능은 준비중입니다!',
-      scrollbarPadding: false,
-      confirmButtonColor: '#222',
-      confirmButtonText: '확인'
-    });
+    showInfoSwal();
   };
 
   return (

--- a/src/components/article/ArticleCard.jsx
+++ b/src/components/article/ArticleCard.jsx
@@ -4,6 +4,7 @@ import { Card, CardActionArea, Typography, Box } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import styled from '@emotion/styled';
 import ColorThief from 'colorthief';
+import { useTitleStore } from '../../store/titleStore';
 
 const StyledCard = styled(Card)`
   position: relative;
@@ -64,6 +65,8 @@ const ArticleCard = ({ article }) => {
   const imageRef = useRef(null);
   const [gradient, setGradient] = useState(null);
   const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const setTitle = useTitleStore((state) => state.setTitle);
+  const setThumbnailUrl = useTitleStore((state) => state.setThumbnailUrl);
 
   // 이미지 URL에서 캐시된 컬러 가져오기
   const cachedColor = useMemo(() => colorCache.get(thumbnailUrl), [thumbnailUrl]);
@@ -107,7 +110,14 @@ const ArticleCard = ({ article }) => {
 
   return (
     <StyledCard elevation={0}>
-      <StyledCardActionArea component={RouterLink} to={`/article/${id}`}>
+      <StyledCardActionArea
+        component={RouterLink}
+        to={`/article/${id}`}
+        onClick={() => {
+          setTitle(title);
+          setThumbnailUrl(thumbnailUrl || defaultThumbnail);
+        }}
+      >
         <CardImage
           ref={imageRef}
           src={thumbnailUrl || defaultThumbnail}

--- a/src/components/comments/CommentItem.jsx
+++ b/src/components/comments/CommentItem.jsx
@@ -1,13 +1,20 @@
 // src/components/comments/CommentItem.jsx
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { ListItem, ListItemAvatar, Avatar, ListItemText, Typography, Box, IconButton, Menu, MenuItem, TextField, Button } from '@mui/material';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import FavoriteIcon from '@mui/icons-material/Favorite';
-import Swal from 'sweetalert2';
-import TokenAxios from '../../api/TokenAxios';
 import SendIcon from '@mui/icons-material/SendRounded';
+
+function getLines(text, maxLines = 4) {
+  // 줄바꿈 기준으로 자르기
+  const lines = text.split('\n');
+  if (lines.length <= maxLines) return { visible: text, hidden: '' };
+  return {
+    visible: lines.slice(0, maxLines).join('\n'),
+    hidden: lines.slice(maxLines).join('\n'),
+  };
+}
 
 function CommentItem({ comment, onDelete, onReply, level, isAuthor = false, likeCount = 0, replyCount = 0, onEdit }) {
   const [editMode, setEditMode] = useState(false);
@@ -15,6 +22,23 @@ function CommentItem({ comment, onDelete, onReply, level, isAuthor = false, like
   const [anchorEl, setAnchorEl] = useState(null);
   const [isLiked, setIsLiked] = useState(false);
   const open = Boolean(anchorEl);
+  const [expanded, setExpanded] = useState(false);
+  const [isLong, setIsLong] = useState(false);
+  const contentRef = useRef(null);
+  const { visible, hidden } = getLines(comment.content, 4);
+
+  useEffect(() => {
+    if (contentRef.current) {
+      // 4줄을 넘어가는지 체크
+      const lineHeight = parseFloat(getComputedStyle(contentRef.current).lineHeight);
+      const maxHeight = lineHeight * 4;
+      if (contentRef.current.scrollHeight > maxHeight + 2) {
+        setIsLong(true);
+      } else {
+        setIsLong(false);
+      }
+    }
+  }, [comment.content]);
 
   const formatDateTime = (dateString) => {
     try {
@@ -89,7 +113,22 @@ function CommentItem({ comment, onDelete, onReply, level, isAuthor = false, like
             </Typography>
           </Box>
         }
-        secondaryTypographyProps={{ component: 'div' }}
+        sx={{
+          overflow: 'visible',
+          textOverflow: 'unset ',
+          whiteSpace: 'normal',
+        }}
+        secondaryTypographyProps={{
+          component: 'div',
+          sx: {
+            overflow: 'visible ',
+            textOverflow: 'unset ',
+            display: 'block ',
+            whiteSpace: 'normal ',
+            WebkitLineClamp: 'unset ',
+            WebkitBoxOrient: 'unset ',
+          }
+        }}
         secondary={
           <React.Fragment>
             {editMode ? (
@@ -158,14 +197,40 @@ function CommentItem({ comment, onDelete, onReply, level, isAuthor = false, like
                 </Button>
               </Box>
             ) : (
-              <Typography
-                component="span"
-                variant="body2"
-                color="text.primary"
-                sx={{ display: 'block', whiteSpace: 'pre-wrap', wordBreak: 'break-word', mb: 0.5 }}
-              >
-                {comment.content}
-              </Typography>
+              <>
+                <Typography
+                  ref={contentRef}
+                  component="div"
+                  variant="body2"
+                  color="text.primary"
+                  sx={{
+                    whiteSpace: 'pre-line',
+                    wordBreak: 'break-word',
+                    mb: 0.5,
+                    display: 'block',
+                  }}
+                >
+                  {expanded ? comment.content : visible}
+                </Typography>
+                {!expanded && hidden && (
+                  <Button
+                    size="small"
+                    sx={{ mt: 0.5, minHeight: 0, minWidth: 0, p: 0, fontSize: 12, color: 'black', display: 'block' }}
+                    onClick={() => setExpanded(true)}
+                  >
+                    ... 자세히보기
+                  </Button>
+                )}
+                {expanded && hidden && (
+                  <Button
+                    size="small"
+                    sx={{ mt: 0.5, minHeight: 0, minWidth: 0, p: 0, fontSize: 12, color: 'black', display: 'block' }}
+                    onClick={() => setExpanded(false)}
+                  >
+                    접기
+                  </Button>
+                )}
+              </>
             )}
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
               <IconButton size="small" onClick={handleLikeClick}>

--- a/src/components/comments/CommentItem.jsx
+++ b/src/components/comments/CommentItem.jsx
@@ -91,7 +91,7 @@ function CommentItem({ comment, onDelete, onReply, level, isAuthor = false, like
         <Avatar
           sx={{ width: 30, height: 30 }}
           alt={comment.author}
-          src={`https://api.dicebear.com/8.x/initials/svg?seed=${comment.author}`}
+          src={`${comment.authorProfileImageUrl}`}
         />
       </ListItemAvatar>
       <ListItemText
@@ -188,10 +188,12 @@ function CommentItem({ comment, onDelete, onReply, level, isAuthor = false, like
                 <FavoriteBorderIcon fontSize="small" />
                 <Typography variant="caption" sx={{ ml: 0.5 }}>{likeCount}</Typography>
               </IconButton>
-              <IconButton size="small" onClick={handleReplyClick}>
-                <ChatBubbleOutlineIcon fontSize="small" />
-                <Typography variant="caption" sx={{ ml: 0.5 }}>{replyCount}</Typography>
-              </IconButton>
+              {level === 0 && (
+                <IconButton size="small" onClick={handleReplyClick}>
+                  <ChatBubbleOutlineIcon fontSize="small" />
+                  <Typography variant="caption" sx={{ ml: 0.5 }}>{replyCount}</Typography>
+                </IconButton>
+              )}
               {isAuthor && (
                 <IconButton size="small" onClick={handleMoreClick}>
                   <MoreHorizIcon fontSize="small" />

--- a/src/components/comments/CommentItem.jsx
+++ b/src/components/comments/CommentItem.jsx
@@ -62,22 +62,6 @@ function CommentItem({ comment, onDelete, onReply, level, isAuthor = false, like
     setEditMode(false);
   };
 
-  const handleCommentEdit = async (commentId, newContent) => {
-    try {
-      await TokenAxios.patch(`/api/v1/webtoons/${articleId}/comments/${commentId}`, {
-        content: newContent
-      });
-      setComments(prev =>
-        prev.map(comment =>
-          comment.id === commentId ? { ...comment, content: newContent } : comment
-        )
-      );
-      Swal.fire('수정 완료', '댓글이 수정되었습니다.', 'success');
-    } catch {
-      Swal.fire('오류', '댓글 수정에 실패했습니다.', 'error');
-    }
-  };
-
   return (
     <ListItem
       alignItems="flex-start"

--- a/src/components/modal/ShowInfoModal.jsx
+++ b/src/components/modal/ShowInfoModal.jsx
@@ -1,0 +1,43 @@
+import Swal from 'sweetalert2';
+
+export function showInfoSwal({
+  title = '해당기능은 준비중입니다!',
+  icon = 'info',
+  confirmButtonText = '확인',
+  confirmButtonColor = '#222',
+  willOpen,
+  willClose,
+  ...rest
+} = {}) {
+  let prevRootStyle = '';
+  Swal.fire({
+    icon,
+    title,
+    scrollbarPadding: false,
+    confirmButtonColor,
+    confirmButtonText,
+    willOpen: () => {
+      document.body.classList.add('swal-blur');
+      const root = document.getElementById('root');
+      if (root) {
+        prevRootStyle = root.style.filter;
+        root.style.filter = 'blur(4px)';
+        root.style.pointerEvents = 'none';
+        root.style.userSelect = 'none';
+        root.style.transition = 'filter 0.1s';
+      }
+      if (willOpen) willOpen();
+    },
+    willClose: () => {
+      document.body.classList.remove('swal-blur');
+      const root = document.getElementById('root');
+      if (root) {
+        root.style.filter = prevRootStyle;
+        root.style.pointerEvents = '';
+        root.style.userSelect = '';
+      }
+      if (willClose) willClose();
+    },
+    ...rest,
+  });
+}

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
+import TokenAxios from '../api/TokenAxios';
 
 const AuthContext = createContext(null);
 
@@ -24,8 +25,11 @@ export function AuthProvider({ children }) {
   }, []);
 
   const logout = useCallback(() => {
-    setUser(null);
     localStorage.removeItem('user');
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    delete TokenAxios.defaults.headers.common['Authorization'];
+    setUser(null);
   }, []);
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,14 @@
 /* src/index.css */
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
 
-html { box-sizing: border-box; /* ... */ }
-*, *::before, *::after { box-sizing: inherit; }
+html { 
+  box-sizing: border-box;
+  overflow-y: scroll; /* 항상 스크롤바 표시 */
+} 
+
+*, *::before, *::after { 
+  box-sizing: inherit; 
+}
 
 body {
   margin: 0;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,11 +7,9 @@ import { BrowserRouter } from 'react-router-dom'; // BrowserRouter import
 import { AuthProvider } from './contexts/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
     <BrowserRouter> {/* BrowserRouter 적용 */}
       <AuthProvider>
       <App />
       </AuthProvider>
     </BrowserRouter>
-  </React.StrictMode>,
 );

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -7,7 +7,6 @@ import Carousel from '../components/Carousel/Carousel';
 import DefaultAxios from '../api/DefaultAxios';
 import CategoryGrid from '../components/grid/CategoryGrid';
 import { useTitleStore } from '../store/titleStore';
-import { HeaderText } from '../components/common/StyledTypography';
 import ArticleInfo from '../components/article/ArticleInfo';
 import CommentButton from '../components/article/CommentButton';
 
@@ -93,8 +92,8 @@ function ArticlePage() {
     <Box sx={{ pb: 7 }}>
       <Box sx={{ position: 'sticky', top: 0, bgcolor: 'white', zIndex: 1, borderBottom: '1px solid rgba(0, 0, 0, 0.12)', px: 2, py: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <IconButton onClick={handleBack} edge="start"><ArrowBackIcon /></IconButton>
-        {/* TODO : 중앙 정렬이 아니라면 오른쪽에 박스 추가 */}
-        <HeaderText variant="subtitle1" component="h1" sx={{ ml: 1, flexGrow: 1 }}>{title}</HeaderText>
+        <Typography variant="subtitle1" component="h1" sx={{ ml: 1, flexGrow: 1, fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', textAlign: 'center' }}>{title}</Typography>
+        <Box sx={{ width: 35, height: 35, ml: 1 }} />
       </Box>
 
       <Box sx={{ p: 2, pt: 3 }}>

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -14,6 +14,7 @@ import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import DefaultAxios from '../api/DefaultAxios';
 import CategoryGrid from '../components/grid/CategoryGrid';
+import { useTitleStore } from '../store/titleStore';
 
 function ArticlePage() {
   const { articleId } = useParams();
@@ -26,7 +27,8 @@ function ArticlePage() {
   const [sourceNews, setSourceNews] = useState([]);
   const [commentCount, setCommentCount] = useState(0);
   const [relatedNews, setRelatedNews] = useState([]);
-  const [title, setTitle] = useState('');
+  const title = useTitleStore((state) => state.title);
+  const thumbnailUrl = useTitleStore((state) => state.thumbnailUrl);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showOriginal, setShowOriginal] = useState(false);
@@ -46,7 +48,6 @@ function ArticlePage() {
         setIsLiked(!!data1?.isLiked);
         setIsBookmarked(!!data1?.isBookmarked);
         setLikeCount(data1?.likeCount || 0);
-        setTitle(data1?.slides?.[0]?.content || '');
         setViewCount(data1?.viewCount || 0);
 
         const res2 = await DefaultAxios.get(`/api/v1/webtoons/${articleId}/details`);
@@ -79,14 +80,22 @@ function ArticlePage() {
 
   return (
     <Box sx={{ pb: 7 }}>
-      <Box sx={{ position: 'sticky', top: 0, bgcolor: 'white', zIndex: 1, borderBottom: '1px solid rgba(0, 0, 0, 0.12)', px: 2, py: 1, display: 'flex', alignItems: 'center' }}>
+      <Box sx={{ position: 'sticky', top: 0, bgcolor: 'white', zIndex: 1, borderBottom: '1px solid rgba(0, 0, 0, 0.12)', px: 2, py: 1, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <IconButton onClick={handleBack} edge="start"><ArrowBackIcon /></IconButton>
-        <Typography variant="subtitle1" component="h1" sx={{ ml: 1, flexGrow: 1, fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{title}</Typography>
+        <Typography variant="subtitle1" component="h1" sx={{ ml: 1, flexGrow: 1, fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', textAlign: 'center' }}>{title}</Typography>
+        <Box sx={{ width: 35, height: 35, ml: 1 }} />
       </Box>
 
       <Box sx={{ p: 2, pt: 3 }}>
         <Carousel
-          items={slides.map((slide) => (
+          items={[
+            ...(thumbnailUrl ? [{
+              slideSeq: 'thumbnail',
+              imageUrl: thumbnailUrl,
+              content: title,
+            }] : []),
+            ...slides
+          ].map((slide) => (
             <SlideWithMoreButton key={slide.slideSeq} slide={slide} />
           ))}
         />

--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -87,10 +87,7 @@ function ArticlePage() {
       <Box sx={{ p: 2, pt: 3 }}>
         <Carousel
           items={slides.map((slide) => (
-            <Box key={slide.slideSeq} sx={{ width: '100%', aspectRatio: '1/1', position: 'relative', borderRadius: 2, overflow: 'hidden' }}>
-              <img src={slide.imageUrl} alt={slide.content} style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
-              <Box sx={{ position: 'absolute', left: 0, bottom: 0, width: '100%', bgcolor: 'rgba(0,0,0,0.4)', color: 'white', p: 1, fontSize: 14 }}>{slide.content}</Box>
-            </Box>
+            <SlideWithMoreButton key={slide.slideSeq} slide={slide} />
           ))}
         />
       </Box>
@@ -152,6 +149,115 @@ function ArticlePage() {
             viewCount: 0,
           }))}
         />
+      </Box>
+    </Box>
+  );
+}
+
+function SlideWithMoreButton({ slide }) {
+  const [showAll, setShowAll] = useState(false);
+  const isLong = slide.content.length > 30;
+
+  // 한 줄일 때만 gradient mask 적용
+  const gradientMask = 'linear-gradient(to right, #fff 80%, transparent 100%)';
+
+  return (
+    <Box sx={{ width: '100%', aspectRatio: '1/1', position: 'relative', borderRadius: 2, overflow: 'hidden' }}>
+      <img
+        src={slide.imageUrl}
+        alt={slide.content}
+        style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', objectFit: 'cover' }}
+      />
+      <Box
+        sx={{
+          position: 'absolute',
+          left: 0,
+          bottom: 0,
+          width: '100%',
+          bgcolor: 'rgba(0,0,0,0.4)',
+          color: 'white',
+          p: 1,
+          fontSize: 14,
+          minHeight: showAll ? 56 : 28,
+          transition: 'min-height 0.2s',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'flex-end',
+        }}
+      >
+        {!showAll ? (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              width: '100%',
+            }}
+          >
+            <Box
+              sx={{
+                overflow: 'hidden',
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                whiteSpace: 'normal',
+                WebkitLineClamp: 1,
+                textOverflow: 'ellipsis',
+                WebkitMaskImage: gradientMask,
+                maskImage: gradientMask,
+                flex: '1 1 auto',
+                transition: 'all 0.2s',
+              }}
+            >
+              {slide.content}
+            </Box>
+            {isLong && (
+              <button
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: 'white',
+                  cursor: 'pointer',
+                  fontSize: 12,
+                  padding: 0,
+                  textDecoration: 'underline',
+                  marginLeft: 8,
+                  flex: '0 0 auto',
+                }}
+                onClick={() => setShowAll(true)}
+              >
+                더보기
+              </button>
+            )}
+          </Box>
+        ) : (
+          <>
+            <Box
+              sx={{
+                overflow: 'hidden',
+                whiteSpace: 'normal',
+                wordBreak: 'break-all',
+                mb: 1,
+              }}
+            >
+              {slide.content}
+            </Box>
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', width: '100%' }}>
+              <button
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: 'white',
+                  cursor: 'pointer',
+                  fontSize: 12,
+                  padding: 0,
+                  textDecoration: 'underline',
+                }}
+                onClick={() => setShowAll(false)}
+              >
+                간략히
+              </button>
+            </Box>
+          </>
+        )}
       </Box>
     </Box>
   );

--- a/src/pages/CategoryPage.jsx
+++ b/src/pages/CategoryPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Container } from '@mui/material';
 import { useNavigate, useParams } from 'react-router-dom';
 import CategoryTabs, { categories } from '../components/tabs/CategoryTabs';
 import CategoryGrid from '../components/grid/CategoryGrid';
@@ -100,9 +100,10 @@ function CategoryPage() {
   }, [activeTab]);
 
   return (
-    <Box sx={{ p: 2 }}>
-      <CategoryTabs activeTab={activeTab} onTabChange={handleTabChange} />
-      <CategoryGrid
+    <Container maxWidth="lg">
+      <Box sx={{ my: 1 }}>
+        <CategoryTabs activeTab={activeTab} onTabChange={handleTabChange} />
+        <CategoryGrid
         title={getCategoryName()}
         time={getTimeString()}
         articles={articles}
@@ -118,6 +119,7 @@ function CategoryPage() {
         </Box>
       )}
     </Box>
+    </Container>
   );
 }
 

--- a/src/pages/CommentPage.jsx
+++ b/src/pages/CommentPage.jsx
@@ -20,8 +20,9 @@ function CommentPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [pageInfo, setPageInfo] = useState(null);
+  const [commentsCount, setCommentsCount] = useState(0);
+  const [subCommentsCount, setSubCommentsCount] = useState(0);
   const location = useLocation();
-  const commentCount = location.state?.commentCount;
   const listRef = useRef(null);
 
   const fetchComments = async (cursor = null) => {
@@ -88,15 +89,6 @@ function CommentPage() {
         parentId: parentId
       });
       setCommentText('');
-      
-      // 댓글 작성 후 댓글 개수 업데이트
-      if (commentCount !== undefined) {
-        const newCommentCount = commentCount + 1;
-        navigate(`/comment/${articleId}`, { 
-          state: { commentCount: newCommentCount },
-          replace: true 
-        });
-      }
       
       fetchComments(); // 댓글 작성 후 목록 새로고침
       if (showReplies && selectedCommentId) {
@@ -177,7 +169,7 @@ function CommentPage() {
             fontWeight: 'bold'
           }}
         >
-          {showReplies ? '답글' : commentCount !== undefined ? `댓글 ${commentCount}개` : `댓글 ${comments.length}개`}
+          {showReplies ?  `답글 ${replies.length}개` : `댓글 ${comments.length}개`}
         </Typography>
       </Box>
 
@@ -278,7 +270,7 @@ function CommentPage() {
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && commentText.trim()) {
+              if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && commentText.trim()) {
                 e.preventDefault();
                 handleCommentSubmit(e);
               }

--- a/src/pages/CommentPage.jsx
+++ b/src/pages/CommentPage.jsx
@@ -338,7 +338,7 @@ function CommentPage() {
               }
             }}
           >
-            댓글을 작성하려면 <Link component={RouterLink} to="/login">로그인</Link>이 필요합니다.
+            댓글을 작성하려면 <Link component={RouterLink} to={`/login?from=${encodeURIComponent(location.pathname)}`}>로그인</Link>이 필요합니다.
           </Alert>
         </Box>
       )}

--- a/src/pages/CommentPage.jsx
+++ b/src/pages/CommentPage.jsx
@@ -88,6 +88,16 @@ function CommentPage() {
         parentId: parentId
       });
       setCommentText('');
+      
+      // 댓글 작성 후 댓글 개수 업데이트
+      if (commentCount !== undefined) {
+        const newCommentCount = commentCount + 1;
+        navigate(`/comment/${articleId}`, { 
+          state: { commentCount: newCommentCount },
+          replace: true 
+        });
+      }
+      
       fetchComments(); // 댓글 작성 후 목록 새로고침
       if (showReplies && selectedCommentId) {
         handleViewReplies(selectedCommentId);
@@ -198,7 +208,7 @@ function CommentPage() {
                   onDelete={handleCommentDelete}
                   onEdit={handleCommentEdit}
                   level={0}
-                  isAuthor={user && comment.author === user.name}
+                  isAuthor={user && comment.author === user.nickname}
                   replyCount={comment.subComments?.length || 0}
                   likeCount={comment.likeCount || 0}
                 />
@@ -217,7 +227,7 @@ function CommentPage() {
                 <CommentItem
                   comment={selectedComment}
                   level={0}
-                  isAuthor={user && selectedComment.author === user.name}
+                  isAuthor={user && selectedComment.author === user.nickname}
                   onDelete={handleCommentDelete}
                   onEdit={handleCommentEdit}
                   replyCount={selectedComment.subComments?.length || 0}
@@ -229,7 +239,7 @@ function CommentPage() {
                   <CommentItem
                     comment={reply}
                     level={1}
-                    isAuthor={user && reply.author === user.name}
+                    isAuthor={user && reply.author === user.nickname}
                     onDelete={handleCommentDelete}
                     onEdit={handleCommentEdit}
                     likeCount={reply.likeCount || 0}
@@ -268,11 +278,10 @@ function CommentPage() {
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey && commentText.trim()) {
+              if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && commentText.trim()) {
                 e.preventDefault();
                 handleCommentSubmit(e);
               }
-              
             }}
             sx={{
               '& .MuiOutlinedInput-root': {

--- a/src/pages/GoogleRedirectHandler.jsx
+++ b/src/pages/GoogleRedirectHandler.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import DefaultAxios from '../api/DefaultAxios';
 
 function GoogleRedirectHandler() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useAuth();
 
   useEffect(() => {
@@ -12,6 +13,7 @@ function GoogleRedirectHandler() {
       try {
         const urlParams = new URLSearchParams(window.location.search);
         const code = urlParams.get('code');
+        const from = urlParams.get('state') || '/';
 
         if (!code) throw new Error('인증 코드를 받지 못했습니다.');
 
@@ -27,7 +29,7 @@ function GoogleRedirectHandler() {
         localStorage.setItem('refreshToken', data.refreshToken);
 
         login(data.userInfo);
-        navigate('/');
+        navigate(from);
       } catch (error) {
         console.error('구글 로그인 처리 중 오류:', error);
         navigate('/login');
@@ -35,7 +37,7 @@ function GoogleRedirectHandler() {
     };
 
     handleGoogleCallback();
-  }, [navigate, login]);
+  }, [navigate, login, location]);
 
   return null;
 }

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -121,6 +121,8 @@ function HomePage() {
                     }} />
                   </Box>
                 ))}
+                autoSlide={true}
+                autoSlideInterval={5000}
               />
             </Box>
           )}

--- a/src/pages/KakaoRedirectHandler.jsx
+++ b/src/pages/KakaoRedirectHandler.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import DefaultAxios from '../api/DefaultAxios';
 
 function KakaoRedirectHandler() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { login } = useAuth();
 
   useEffect(() => {
@@ -12,6 +13,7 @@ function KakaoRedirectHandler() {
       try {
         const urlParams = new URLSearchParams(window.location.search);
         const code = urlParams.get('code');
+        const from = urlParams.get('state') || '/';
 
         if (!code) throw new Error('카카오 인증 코드를 받지 못했습니다.');
 
@@ -27,7 +29,7 @@ function KakaoRedirectHandler() {
         localStorage.setItem('refreshToken', data.refreshToken);
 
         login(data.userInfo);
-        navigate('/');
+        navigate(from);
       } catch (error) {
         console.error('카카오 로그인 처리 중 오류:', error);
         navigate('/login');
@@ -35,7 +37,7 @@ function KakaoRedirectHandler() {
     };
 
     handleKakaoCallback();
-  }, [navigate, login]);
+  }, [navigate, login, location]);
 
   return null;
 }

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -15,18 +15,21 @@ function LoginPage() {
     const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
     const redirectUri = import.meta.env.VITE_GOOGLE_REDIRECT_URI;
     const scope = 'openid email profile';
+    const from = new URLSearchParams(window.location.search).get('from') || '/';
 
     const url = `${authUrl}`
       + `?client_id=${encodeURIComponent(clientId)}`
       + `&redirect_uri=${encodeURIComponent(redirectUri)}`
       + `&response_type=code`
-      + `&scope=${encodeURIComponent(scope)}`;
+      + `&scope=${encodeURIComponent(scope)}`
+      + `&state=${encodeURIComponent(from)}`;
 
     window.location.assign(url);
   };
 
   const handleKakaoLogin = () => {
-    const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_KAKAO_REST_API_KEY}&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URI}&response_type=code`;
+    const from = new URLSearchParams(window.location.search).get('from') || '/';
+    const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${import.meta.env.VITE_KAKAO_REST_API_KEY}&redirect_uri=${import.meta.env.VITE_KAKAO_REDIRECT_URI}&response_type=code&state=${encodeURIComponent(from)}`;
     window.location.href = KAKAO_AUTH_URL;
   };
 
@@ -97,7 +100,7 @@ function LoginPage() {
           refreshToken: sessionStorage.getItem("refreshToken")
         });
 
-        // 홈페이지로 이동
+        // 이전 화면으로 이동
         navigate('/');
       } else if (accessToken && refreshToken) {
         // URL에 토큰이 직접 포함된 경우
@@ -108,7 +111,8 @@ function LoginPage() {
           accessToken: sessionStorage.getItem("accessToken"),
           refreshToken: sessionStorage.getItem("refreshToken")
         });
-        navigate('/');
+        // 이전 화면으로 이동
+        navigate('-1');
       }
     } catch (error) {
       const errorLog = {
@@ -150,7 +154,7 @@ function LoginPage() {
           left: 20,
         }}
       >
-        <IconButton onClick={() => navigate('/')}>
+        <IconButton onClick={() => navigate(-1)}>
           <ArrowBackIcon />
         </IconButton>
       </Box>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 // src/pages/LoginPage.jsx
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { Box, Typography, IconButton, Button } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import newsumLogo from '../assets/newsum_logo.jpeg';
@@ -9,6 +9,8 @@ import kakaoLoginBtn from '../assets/kakao_login.png';
 
 function LoginPage() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const from = new URLSearchParams(location.search).get('from') || '/';
 
   const handleGoogleLogin = () => {
     const authUrl = 'https://accounts.google.com/o/oauth2/auth';
@@ -126,6 +128,10 @@ function LoginPage() {
     }
   };
 
+  const handleBack = () => {
+    navigate(from);
+  };
+
   // 컴포넌트 마운트 시 토큰 확인
   React.useEffect(() => {
     const log = {
@@ -154,7 +160,7 @@ function LoginPage() {
           left: 20,
         }}
       >
-        <IconButton onClick={() => navigate(-1)}>
+        <IconButton onClick={handleBack}>
           <ArrowBackIcon />
         </IconButton>
       </Box>

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -30,8 +30,9 @@ function MyProfilePage() {
 
   const handleLogout = () => {
     setOpen(false);
-    sessionStorage.clear();
     localStorage.removeItem('profileImage');
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
     localStorage.removeItem('user');
     navigate(-1);
   };

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -3,9 +3,11 @@ import { Box, Typography, Button, Avatar, IconButton, Modal } from '@mui/materia
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useNavigate } from 'react-router-dom';
 import logoutLogo from '../assets/logout_logo.jpeg';
+import { useAuth } from '../contexts/AuthContext';
 
 function MyProfilePage() {
   const navigate = useNavigate();
+  const { logout } = useAuth();
   const [user, setUser] = useState(null);
   const [profileImg, setProfileImg] = useState('');
   const [open, setOpen] = useState(false);
@@ -30,11 +32,7 @@ function MyProfilePage() {
 
   const handleLogout = () => {
     setOpen(false);
-    localStorage.removeItem('profileImage');
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
-    localStorage.removeItem('user');
-    setUser(null);
+    logout();
     navigate(-1);
   };
 

--- a/src/pages/MyProfilePage.jsx
+++ b/src/pages/MyProfilePage.jsx
@@ -53,7 +53,7 @@ function MyProfilePage() {
     localStorage.clear();
     localStorage.removeItem('profileImage');
     localStorage.removeItem('user');
-    navigate('/');
+    navigate(-1);
   };
 
   const handleCancel = () => setOpen(false);

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import MainLayout from '../components/Layout/MainLayout';
 import NoHeaderLayout from '../components/Layout/NoHeaderLayout'
+import ArticleLayout from '../components/Layout/ArticleLayout';
 import HomePage from '../pages/HomePage';
 import ArticlePage from '../pages/ArticlePage';
 import LoginPage from '../pages/LoginPage';
@@ -30,6 +31,9 @@ function Router() {
       <Route element={<MainLayout />}>
         <Route path="/" element={<HomePage />} />
         <Route path="/category/:category_id" element={<CategoryPage />} />
+      </Route>
+
+      <Route element={<ArticleLayout />}>
         <Route path='/article/:articleId' element={<ArticlePage />} />
       </Route>
 

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -21,7 +21,7 @@ function Router() {
       {/* <Route path="/login" element={<GoogleRedirectHandler />} /> */}
       <Route path="/oauth2/callback/google" element={<GoogleRedirectHandler />} />
       <Route path="/oauth2/callback/kakao" element={<KakaoRedirectHandler />} />
-      <Route path='/comment/:articleId' element={<CommentPage />} />
+      <Route path='/article/:articleId/comments' element={<CommentPage />} />
 
       {/* ⭐️ 기존 헤더/바텀네비 없는 단독 페이지로 분리 ⭐️ */}
 

--- a/src/store/titleStore.js
+++ b/src/store/titleStore.js
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export const useTitleStore = create(
+  persist(
+    (set) => ({
+      title: '',
+      setTitle: (title) => set({ title }),
+      thumbnailUrl: '',
+      setThumbnailUrl: (thumbnailUrl) => set({ thumbnailUrl }),
+    }),
+    {
+      name: 'webtoon-title-storage', // localStorage key
+      partialize: (state) => ({ title: state.title, thumbnailUrl: state.thumbnailUrl }), // title, thumbnailUrl만 저장
+    }
+  )
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

#120 

## 📝작업 내용

> 1. 댓글 페이지와 웹툰 상세 페이지에서 QA간 발생한 오류 수정
> 2. 댓글 UI 수정, 2개씩 입력되는 문제 해결
> 3. 모달 띄워질 때 전체화면 블러처리
> 4. dev 코드 pull 받은 후 충돌 해결
> 5. 댓글 페이지 라우팅 수정
> 6. 모달 컴포넌트화
> 7. 라우팅 될때 화면 이동하던거 스크롤바 만들어 고정
> 8. 메인페이지와 카테고리 페이지의 탭 위치 고정
> 9. 로그아웃 후 댓글 작성 되는 문제 해결
> 10. 로그인 라우팅 문제 해결

### 스크린샷

#### 웹툰상세페이지

제목 중간 정렬, 썸네일 부터 캐러셀에 넣어 5슬라이드로, 캐러셀 자동이동 삭제
<img width="553" alt="image" src="https://github.com/user-attachments/assets/e62b2d97-8109-41fd-9d0e-c60bd7b4842d" />

웹툰 대사 그라데이션 영역 더보기 버튼 추가
<img width="513" alt="image" src="https://github.com/user-attachments/assets/ccea7481-6566-4e0a-9be2-4bc9663167bb" />
<img width="574" alt="image" src="https://github.com/user-attachments/assets/0064cee3-517d-43fa-9168-3970fd2fdbb3" />

모바일으로 들어갔을 때 슬라이드로 슬라이드 이동 가능하게 수정

#### 댓글 페이지

댓글 한글로 입력시 2개가 입력되는 오류 수정, 프로필 사진 안불러와지는 오류 수정
<img width="541" alt="image" src="https://github.com/user-attachments/assets/9139b79d-dc26-4a26-82ec-58ebe474448e" />

하위 댓글 입력할때 답글 버튼 나오는 오류 수정
<img width="552" alt="image" src="https://github.com/user-attachments/assets/ef0373a4-5af1-4bed-b4c8-6626aaef73e4" />

로그인 시 메인페이지로 이동하는 문제 수정

#### 전체페이지 UI 수정

모달 전체 블러처리
<img width="584" alt="image" src="https://github.com/user-attachments/assets/db122e71-3219-4322-8eb0-59f839b18039" />

탭 위치 고정
1. 메인페이지
<img width="533" alt="image" src="https://github.com/user-attachments/assets/594ade8e-3bab-4e28-80b1-4f25729a69ab" />

2. 카테고리 페이지
<img width="532" alt="image" src="https://github.com/user-attachments/assets/65bf7d3a-255f-4e8a-b7c6-b2b15eaf87dc" />



## 💬리뷰 요구사항(선택)

#120 번 브랜치 들어가서 실행시킨 후에 기능 잘 되는지 확인 부탁드립니다!