### PR TITLE
[#180]키워드 즐겨찾기 페이지 UI 구현 및 등록 api 연동

### DIFF
--- a/src/components/Layout/BottomNav.jsx
+++ b/src/components/Layout/BottomNav.jsx
@@ -118,8 +118,16 @@ function BottomNav() {
   ];
 
   useEffect(() => {
-    const currentNavItem = navItems.find(item => location.pathname.startsWith(item.value) && item.value !== '/');
-    setValue(currentNavItem ? currentNavItem.value : (location.pathname === '/' ? '/' : ''));
+    if (
+      location.pathname.startsWith('/bookmarks') ||
+      location.pathname.startsWith('/keyword-bookmarks') ||
+      location.pathname.startsWith('/keyword-add')
+    ) {
+      setValue('/bookmarks');
+    } else {
+      const currentNavItem = navItems.find(item => location.pathname.startsWith(item.value) && item.value !== '/');
+      setValue(currentNavItem ? currentNavItem.value : (location.pathname === '/' ? '/' : ''));
+    }
   }, [location.pathname]);
 
   const handleChange = (event, newValue) => {

--- a/src/components/bookmark/BookmarkMenu.jsx
+++ b/src/components/bookmark/BookmarkMenu.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Slide, Paper, Box, Button } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+/**
+ * 북마크 하단 메뉴 컴포넌트
+ * 
+ * @param {Object} props
+ * @param {boolean} props.open - 메뉴 표시 여부
+ * @param {Function} props.onAddClick - 북마크 추가 버튼 클릭 핸들러
+ * @param {Function} props.onDeleteClick - 북마크 삭제 버튼 클릭 핸들러
+ */
+function BookmarkMenu({ open, onAddClick, onDeleteClick }) {
+    return (
+        <Slide direction="up" in={open} mountOnEnter unmountOnExit>
+            <Paper
+                sx={{
+                    position: 'fixed',
+                    bottom: '50px',
+                    left: 0,
+                    right: 0,
+                    zIndex: 1000,
+                    borderTopLeftRadius: '16px',
+                    borderTopRightRadius: '16px',
+                    boxShadow: '0 -4px 20px rgba(0, 0, 0, 0.1)',
+                    maxWidth: '430px',
+                    margin: '0 auto',
+                }}
+            >
+                <Box sx={{ p: 2 }}>
+                    <Button
+                        fullWidth
+                        startIcon={<AddIcon />}
+                        onClick={onAddClick}
+                        sx={{
+                            justifyContent: 'flex-start',
+                            py: 1.5,
+                            color: 'text.primary',
+                            '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.04)' },
+                        }}
+                    >
+                        북마크 추가하기
+                    </Button>
+                    <Button
+                        fullWidth
+                        startIcon={<DeleteIcon />}
+                        onClick={onDeleteClick}
+                        sx={{
+                            justifyContent: 'flex-start',
+                            py: 1.5,
+                            color: 'text.primary',
+                            '&:hover': { backgroundColor: 'rgba(0, 0, 0, 0.04)' },
+                        }}
+                    >
+                        북마크 삭제하기
+                    </Button>
+                </Box>
+            </Paper>
+        </Slide>
+    );
+}
+
+export default BookmarkMenu; 

--- a/src/components/dropdown/CategoryDropdown.jsx
+++ b/src/components/dropdown/CategoryDropdown.jsx
@@ -3,11 +3,13 @@ import { Box, Button } from '@mui/material';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import { showInfoSwal } from '../modal/ShowInfoModal';
 
 const CATEGORY = {
-    WRITERS: 'AI작가 즐겨찾기',
-    KEYWORDS: '키워드 즐겨찾기',
-    WEBTOONS: '웹툰 즐겨찾기',
+  WRITERS: 'AI작가 즐겨찾기',
+  KEYWORDS: '키워드 즐겨찾기',
+  WEBTOONS: '웹툰 즐겨찾기',
 };
 
 const DropdownContainer = styled(Box)`
@@ -81,53 +83,64 @@ const HeaderContainer = styled(Box)`
 `;
 
 function CategoryDropdown({ selectedCategory, onCategoryChange }) {
-    const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const navigate = useNavigate();
 
-    const handleMenuItemClick = (category) => {
-        onCategoryChange(category);
-        setIsOpen(false);
-    };
+  const handleMenuItemClick = (category) => {
+    if (category === CATEGORY.KEYWORDS) {
+      navigate('/keyword-bookmarks');
+    } else if (category === CATEGORY.WEBTOONS) {
+      navigate('/bookmarks');
+    } else if (category === CATEGORY.WRITERS) {
+      showInfoSwal();
+    }
+    setIsOpen(false);
+  };
 
-    return (
-        <DropdownContainer>
-            <Button
-                onClick={() => setIsOpen(!isOpen)}
+  return (
+    <DropdownContainer>
+      <Button
+        onClick={() => setIsOpen(!isOpen)}
+        sx={{
+          textTransform: 'none',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          color: 'text.primary',
+          mt: -0.5,
+          '&:hover': { backgroundColor: 'transparent' },
+        }}
+        endIcon={isOpen ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+      >
+        {selectedCategory}
+      </Button>
+
+      {isOpen && (
+        <>
+          {/* 배경 오버레이 */}
+          <Overlay onClick={() => setIsOpen(false)} />
+          {/* 드롭다운 메뉴 */}
+          <DropdownMenu>
+            {Object.values(CATEGORY).map((cat) => (
+              <MenuItem
+                key={cat}
+                onClick={() => handleMenuItemClick(cat)}
+                selected={cat === selectedCategory}
                 sx={{
-                    textTransform: 'none',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: '1rem',
-                    fontWeight: 'bold',
-                    color: 'text.primary',
-                    mt: -0.5,
-                    '&:hover': { backgroundColor: 'transparent' },
+                  opacity: cat === CATEGORY.WRITERS ? 0.5 : 1,
+                  cursor: cat === CATEGORY.WRITERS ? 'not-allowed' : 'pointer',
                 }}
-                endIcon={isOpen ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
-            >
-                {selectedCategory}
-            </Button>
-
-            {isOpen && (
-                <>
-                    {/* 배경 오버레이 */}
-                    <Overlay onClick={() => setIsOpen(false)} />
-                    {/* 드롭다운 메뉴 */}
-                    <DropdownMenu>
-                        {Object.values(CATEGORY).map((cat) => (
-                            <MenuItem
-                                key={cat}
-                                onClick={() => handleMenuItemClick(cat)}
-                                selected={cat === selectedCategory}
-                            >
-                                {cat}
-                            </MenuItem>
-                        ))}
-                    </DropdownMenu>
-                </>
-            )}
-        </DropdownContainer>
-    );
+              >
+                {cat}
+              </MenuItem>
+            ))}
+          </DropdownMenu>
+        </>
+      )}
+    </DropdownContainer>
+  );
 }
 
 export default CategoryDropdown; 

--- a/src/components/modal/InfoAlertModal.jsx
+++ b/src/components/modal/InfoAlertModal.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect } from 'react';
+import { Modal, Box, Typography, Button } from '@mui/material';
+import logoutLogo from '../../assets/logout_logo.jpeg';
+
+function InfoAlertModal({ open, onClose, message, image, autoCloseMs }) {
+    useEffect(() => {
+        if (open && autoCloseMs) {
+            const timer = setTimeout(() => {
+                onClose();
+            }, autoCloseMs);
+            return () => clearTimeout(timer);
+        }
+    }, [open, autoCloseMs, onClose]);
+
+    return (
+        <Modal open={open} onClose={onClose}>
+            <Box sx={{
+                position: 'absolute',
+                top: '40%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                bgcolor: '#fff',
+                borderRadius: 3,
+                boxShadow: 24,
+                width: 320,
+                height: 320,
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'center',
+                outline: 'none'
+            }}>
+                <Box
+                    component="img"
+                    src={image || logoutLogo}
+                    alt="안내"
+                    sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }}
+                />
+                <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center' }}>
+                    {message}
+                </Typography>
+                <Button
+                    onClick={onClose}
+                    variant="contained"
+                    sx={{ mt: 3, bgcolor: '#111', color: '#fff', borderRadius: 2, fontWeight: 600 }}
+                >
+                    확인
+                </Button>
+            </Box>
+        </Modal>
+    );
+}
+
+export default InfoAlertModal; 

--- a/src/pages/BookmarkPage.jsx
+++ b/src/pages/BookmarkPage.jsx
@@ -8,8 +8,12 @@ import {
   Alert,
   Container,
   IconButton,
+  Slide,
+  Paper,
+  Button,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import TokenAxios from '../api/TokenAxios';
 import { useAuth } from '../contexts/AuthContext';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -17,6 +21,7 @@ import MoveLogin from '../components/modal/MoveLogin';
 import CategoryGrid from '../components/grid/CategoryGrid';
 import { showInfoSwal } from '../components/modal/ShowInfoModal';
 import CategoryDropdown from '../components/dropdown/CategoryDropdown';
+import BookmarkMenu from '../components/bookmark/BookmarkMenu';
 
 function BookmarkPage() {
   const { isLoggedIn } = useAuth();
@@ -46,6 +51,7 @@ function BookmarkPage() {
   const [pageInfoWebtoons, setPageInfoWebtoons] = useState(null);
 
   const [loginModalOpen, setLoginModalOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   // 뒤로 가기 버튼 핸들러
   const handleBack = () => {
@@ -225,6 +231,20 @@ function BookmarkPage() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, [handleScroll]);
 
+  const handleMenuClick = () => {
+    setMenuOpen(!menuOpen);
+  };
+
+  const handleAddBookmark = () => {
+    setMenuOpen(false);
+    // 북마크 추가 로직 구현
+  };
+
+  const handleDeleteBookmark = () => {
+    setMenuOpen(false);
+    // 북마크 삭제 로직 구현
+  };
+
   // 로딩 스피너: 비어 있는 상태에서 로딩 중인 경우
   if (
     (selectedCategory === 'AI작가 즐겨찾기' && loadingWriters && writers.length === 0) ||
@@ -292,8 +312,24 @@ function BookmarkPage() {
           onCategoryChange={handleCategoryChange}
         />
 
-        <Box sx={{ width: 35, height: 35, ml: 1, mt: -0.5 }} />
+        <IconButton
+          onClick={handleMenuClick}
+          sx={{
+            p: 0.5,
+            mt: -0.5,
+            '&:hover': { backgroundColor: 'transparent' },
+          }}
+        >
+          <MoreVertIcon sx={{ fontSize: '1.5rem' }} />
+        </IconButton>
       </Box>
+
+      {/* 하단 메뉴 */}
+      <BookmarkMenu
+        open={menuOpen}
+        onAddClick={handleAddBookmark}
+        onDeleteClick={handleDeleteBookmark}
+      />
 
       {/* 선택된 카테고리에 따라 내용을 렌더링 */}
       <Container maxWidth="lg" sx={{ overflowX: 'hidden', pt: 2 }}>

--- a/src/pages/KeywordAddPage.jsx
+++ b/src/pages/KeywordAddPage.jsx
@@ -47,7 +47,15 @@ function KeywordAddPage() {
         setInput(value);
     };
 
+    const handleInputKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            handleAdd();
+        }
+    };
+
     const handleAdd = async () => {
+        if (loading) return;
         if (!input.trim() || keywords.length >= MAX_KEYWORDS || input.length > 20) return;
         setLoading(true);
         try {
@@ -127,6 +135,7 @@ function KeywordAddPage() {
                     <Button
                         variant="outlined"
                         size="small"
+                        type="button"
                         sx={{
                             ml: 'auto',
                             borderRadius: 2,
@@ -161,6 +170,7 @@ function KeywordAddPage() {
                         placeholder="예) 삼성전자"
                         value={input}
                         onChange={handleInputChange}
+                        onKeyDown={handleInputKeyDown}
                         inputProps={{ maxLength: 20 }}
                         sx={{ flex: 1, fontSize: '1rem', color: '#aaa' }}
                     />

--- a/src/pages/KeywordAddPage.jsx
+++ b/src/pages/KeywordAddPage.jsx
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+import {
+    Box,
+    Typography,
+    Container,
+    IconButton,
+    Button,
+    InputBase,
+    Divider
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CloseIcon from '@mui/icons-material/Close';
+import { useNavigate } from 'react-router-dom';
+import BottomNav from '../components/Layout/BottomNav';
+
+const MAX_KEYWORDS = 20;
+
+function KeywordAddPage() {
+    const navigate = useNavigate();
+    const [keywords, setKeywords] = useState(['머스크', '엔비디아']);
+    const [input, setInput] = useState('');
+
+    const handleBack = () => {
+        navigate(-1);
+    };
+
+    const handleInputChange = (e) => {
+        setInput(e.target.value);
+    };
+
+    const handleAdd = () => {
+        if (input.trim() && keywords.length < MAX_KEYWORDS) {
+            setKeywords([...keywords, input.trim()]);
+            setInput('');
+        }
+    };
+
+    const handleRemove = (idx) => {
+        setKeywords(keywords.filter((_, i) => i !== idx));
+    };
+
+    return (
+        <Box sx={{ pb: 7, minHeight: '100vh', bgcolor: '#fff' }}>
+            {/* 상단 헤더 */}
+            <Box
+                sx={{
+                    position: 'sticky',
+                    top: 0,
+                    bgcolor: 'white',
+                    zIndex: 10,
+                    borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+                    px: 2,
+                    py: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '44px',
+                }}
+            >
+                <IconButton
+                    onClick={handleBack}
+                    edge="start"
+                    sx={{
+                        p: 0.5,
+                        mt: -0.5,
+                        '&:hover': { backgroundColor: 'transparent' },
+                    }}
+                >
+                    <ArrowBackIcon sx={{ fontSize: '1.5rem' }} />
+                </IconButton>
+                <Typography
+                    variant="h6"
+                    sx={{
+                        flex: 1,
+                        textAlign: 'center',
+                        fontSize: '1.1rem',
+                        fontWeight: 500,
+                    }}
+                >
+                    키워드 추가
+                </Typography>
+                <Box sx={{ width: 40 }} />
+            </Box>
+
+            {/* 키워드 입력 및 추가 */}
+            <Container maxWidth="lg" sx={{ pt: 4, pb: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                    <Typography sx={{ fontWeight: 500, fontSize: '1rem' }}>
+                        키워드({keywords.length}/{MAX_KEYWORDS})
+                    </Typography>
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        sx={{ ml: 'auto', borderRadius: 2, minWidth: 56, height: 32, fontWeight: 500 }}
+                        onClick={handleAdd}
+                        disabled={!input.trim() || keywords.length >= MAX_KEYWORDS}
+                    >
+                        추가
+                    </Button>
+                </Box>
+                <Box
+                    sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        mb: 1,
+                        pb: 0.5,
+                    }}
+                >
+                    <InputBase
+                        placeholder="예) 삼성전자"
+                        value={input}
+                        onChange={handleInputChange}
+                        inputProps={{ maxLength: 20 }}
+                        sx={{ flex: 1, fontSize: '1rem', color: '#aaa' }}
+                    />
+                    <Typography sx={{ color: '#aaa', fontSize: '0.95rem', ml: 1 }}>
+                        {input.length}/20
+                    </Typography>
+                </Box>
+                <Divider sx={{ mb: 1 }} />
+                {/* 키워드 리스트 */}
+                {keywords.map((kw, idx) => (
+                    <Box
+                        key={kw + idx}
+                        sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            borderBottom: '1px solid #eee',
+                            py: 1,
+                            fontSize: '1.1rem',
+                        }}
+                    >
+                        <Typography sx={{ flex: 1, fontSize: '1.1rem', color: '#222' }}>{kw}</Typography>
+                        <IconButton onClick={() => handleRemove(idx)} size="small">
+                            <CloseIcon sx={{ fontSize: 22 }} />
+                        </IconButton>
+                    </Box>
+                ))}
+            </Container>
+            <BottomNav />
+        </Box>
+    );
+}
+
+export default KeywordAddPage; 

--- a/src/pages/KeywordAddPage.jsx
+++ b/src/pages/KeywordAddPage.jsx
@@ -17,6 +17,7 @@ import TokenAxios from '../api/TokenAxios';
 import { useAuth } from '../contexts/AuthContext';
 import Swal from 'sweetalert2';
 import logoutLogo from '../assets/logout_logo.jpeg';
+import InfoAlertModal from '../components/modal/InfoAlertModal';
 
 const MAX_KEYWORDS = 20;
 
@@ -206,21 +207,12 @@ function KeywordAddPage() {
             <BottomNav />
 
             {/* 중복 키워드 안내 모달 */}
-            <Modal open={duplicateModalOpen} onClose={() => setDuplicateModalOpen(false)}>
-                <Box sx={{ position: 'absolute', top: '40%', left: '50%', transform: 'translate(-50%, -50%)', bgcolor: '#fff', borderRadius: 3, boxShadow: 24, width: 320, height: 320, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', outline: 'none' }}>
-                    <Box component="img" src={logoutLogo} alt="중복 안내" sx={{ width: 90, height: 90, borderRadius: '50%', objectFit: 'cover', mb: 2 }} />
-                    <Typography sx={{ fontWeight: 600, fontSize: 18, textAlign: 'center' }}>
-                        이미 구독한 키워드입니다!
-                    </Typography>
-                    <Button
-                        onClick={() => setDuplicateModalOpen(false)}
-                        variant="contained"
-                        sx={{ mt: 3, bgcolor: '#111', color: '#fff', borderRadius: 2, fontWeight: 600 }}
-                    >
-                        확인
-                    </Button>
-                </Box>
-            </Modal>
+            <InfoAlertModal
+                open={duplicateModalOpen}
+                onClose={() => setDuplicateModalOpen(false)}
+                message="이미 구독한 키워드입니다!"
+                autoCloseMs={1000}
+            />
         </Box>
     );
 }

--- a/src/pages/KeywordBookmarkPage.jsx
+++ b/src/pages/KeywordBookmarkPage.jsx
@@ -30,7 +30,7 @@ function KeywordBookmarkPage() {
 
     const handleAddBookmark = () => {
         setMenuOpen(false);
-        // 북마크 추가 로직 구현
+        navigate('/keyword-add');
     };
 
     const handleDeleteBookmark = () => {

--- a/src/pages/KeywordBookmarkPage.jsx
+++ b/src/pages/KeywordBookmarkPage.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import {
+    Box,
+    Typography,
+    Container,
+    IconButton,
+} from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { useNavigate } from 'react-router-dom';
+import CategoryDropdown from '../components/dropdown/CategoryDropdown';
+import BookmarkMenu from '../components/bookmark/BookmarkMenu';
+
+function KeywordBookmarkPage() {
+    const navigate = useNavigate();
+    const [menuOpen, setMenuOpen] = useState(false);
+    const [selectedCategory, setSelectedCategory] = useState('키워드 즐겨찾기');
+
+    const handleBack = () => {
+        navigate(-1);
+    };
+
+    const handleMenuClick = () => {
+        setMenuOpen(!menuOpen);
+    };
+
+    const handleCategoryChange = (category) => {
+        setSelectedCategory(category);
+    };
+
+    const handleAddBookmark = () => {
+        setMenuOpen(false);
+        // 북마크 추가 로직 구현
+    };
+
+    const handleDeleteBookmark = () => {
+        setMenuOpen(false);
+        // 북마크 삭제 로직 구현
+    };
+
+    return (
+        <Box sx={{ pb: 7 }}>
+            {/* 상단 헤더 */}
+            <Box
+                sx={{
+                    position: 'sticky',
+                    top: 0,
+                    bgcolor: 'white',
+                    zIndex: 10,
+                    borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+                    px: 2,
+                    py: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '44px',
+                }}
+            >
+                <IconButton
+                    onClick={handleBack}
+                    edge="start"
+                    sx={{
+                        p: 0.5,
+                        mt: -0.5,
+                        '&:hover': { backgroundColor: 'transparent' },
+                    }}
+                >
+                    <ArrowBackIcon sx={{ fontSize: '1.5rem' }} />
+                </IconButton>
+
+                <CategoryDropdown
+                    selectedCategory={selectedCategory}
+                    onCategoryChange={handleCategoryChange}
+                />
+
+                <IconButton
+                    onClick={handleMenuClick}
+                    sx={{
+                        p: 0.5,
+                        mt: -0.5,
+                        '&:hover': { backgroundColor: 'transparent' },
+                    }}
+                >
+                    <MoreVertIcon sx={{ fontSize: '1.5rem' }} />
+                </IconButton>
+            </Box>
+
+            {/* 하단 메뉴 */}
+            <BookmarkMenu
+                open={menuOpen}
+                onAddClick={handleAddBookmark}
+                onDeleteClick={handleDeleteBookmark}
+            />
+
+            {/* 컨텐츠 영역 */}
+            <Container maxWidth="lg" sx={{ overflowX: 'hidden', pt: 2 }}>
+                <Box sx={{ textAlign: 'center', py: 4 }}>
+                    <Typography variant="h6" color="text.secondary">
+                        키워드 즐겨찾기 항목이 없습니다.
+                    </Typography>
+                </Box>
+            </Container>
+        </Box>
+    );
+}
+
+export default KeywordBookmarkPage; 

--- a/src/pages/KeywordBookmarkPage.jsx
+++ b/src/pages/KeywordBookmarkPage.jsx
@@ -10,11 +10,15 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { useNavigate } from 'react-router-dom';
 import CategoryDropdown from '../components/dropdown/CategoryDropdown';
 import BookmarkMenu from '../components/bookmark/BookmarkMenu';
+import MoveLogin from '../components/modal/MoveLogin';
+import { useAuth } from '../contexts/AuthContext';
 
 function KeywordBookmarkPage() {
     const navigate = useNavigate();
+    const { isLoggedIn } = useAuth();
     const [menuOpen, setMenuOpen] = useState(false);
     const [selectedCategory, setSelectedCategory] = useState('키워드 즐겨찾기');
+    const [loginModalOpen, setLoginModalOpen] = useState(false);
 
     const handleBack = () => {
         navigate(-1);
@@ -30,6 +34,10 @@ function KeywordBookmarkPage() {
 
     const handleAddBookmark = () => {
         setMenuOpen(false);
+        if (!isLoggedIn) {
+            setLoginModalOpen(true);
+            return;
+        }
         navigate('/keyword-add');
     };
 
@@ -91,6 +99,8 @@ function KeywordBookmarkPage() {
                 onAddClick={handleAddBookmark}
                 onDeleteClick={handleDeleteBookmark}
             />
+
+            <MoveLogin open={loginModalOpen} onCancel={() => setLoginModalOpen(false)} from={location.pathname} />
 
             {/* 컨텐츠 영역 */}
             <Container maxWidth="lg" sx={{ overflowX: 'hidden', pt: 2 }}>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -129,7 +129,11 @@ function LoginPage() {
   };
 
   const handleBack = () => {
-    navigate(from);
+    if (from) {
+      navigate(from);
+    } else {
+      navigate(-1);
+    }
   };
 
   // 컴포넌트 마운트 시 토큰 확인

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -16,6 +16,7 @@ import RecentPage from '../pages/RecentPage';
 import EditProfilePage from '../pages/EditProfilePage';
 import BookmarkPage from '../pages/BookmarkPage';
 import SearchPage from '../pages/SearchPage';
+import KeywordBookmarkPage from '../pages/KeywordBookmarkPage';
 
 function Router() {
   return (
@@ -46,6 +47,7 @@ function Router() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/search" element={<SearchPage />} />
         <Route path="/bookmarks" element={<BookmarkPage />} />
+        <Route path="/keyword-bookmarks" element={<KeywordBookmarkPage />} />
       </Route>
     </Routes>
   );

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -17,6 +17,7 @@ import EditProfilePage from '../pages/EditProfilePage';
 import BookmarkPage from '../pages/BookmarkPage';
 import SearchPage from '../pages/SearchPage';
 import KeywordBookmarkPage from '../pages/KeywordBookmarkPage';
+import KeywordAddPage from '../pages/KeywordAddPage';
 
 function Router() {
   return (
@@ -48,6 +49,7 @@ function Router() {
         <Route path="/search" element={<SearchPage />} />
         <Route path="/bookmarks" element={<BookmarkPage />} />
         <Route path="/keyword-bookmarks" element={<KeywordBookmarkPage />} />
+        <Route path="/keyword-add" element={<KeywordAddPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

#180 

## 📝작업 내용

1. 키워드 북마크 적용 페이지 구현
2. 상단 드롭메뉴로 키워드 북마크 전용 페이지 이동 구현
3. 키워드 북마크 적용 페이지 api 연동
### 스크린샷
![image](https://github.com/user-attachments/assets/e1078c5d-241c-4b95-bb1c-997bf07d40d7)
![image](https://github.com/user-attachments/assets/4ac407b3-156f-467c-86eb-d328d50449e7)
하단의 북마크 추가를 클릭하여 키워드 추가 페이지로 이동 합니다
![image](https://github.com/user-attachments/assets/823ac4fd-7d99-4ab3-9c32-07f165c5feaa)


## 💬리뷰 요구사항(선택)
