### PR TITLE
s3 이동 폴더명 수정

### DIFF
--- a/.github/workflows/fe-prod-s3-cd.yml
+++ b/.github/workflows/fe-prod-s3-cd.yml
@@ -31,7 +31,7 @@ jobs:
           aws-region: ap-northeast-2
 
       - name: Sync to S3
-        run: aws s3 sync build/ s3://${{ secrets.S3_BUCKET_NAME_FE }} --delete
+        run: aws s3 sync dist/ s3://${{ secrets.S3_BUCKET_NAME_FE }} --delete
 
       - name: Invalidate CloudFront Cache
         run: |


### PR DESCRIPTION
build->dist

## #️⃣연관된 이슈
aws s3 cd 과정 중 build 폴더가 존재하지 않아서 오류 발생

## 📝작업 내용

build-> dist로 변경

