### PR TITLE
웹툰 상세페이지에서 실시간 웹툰 시청자 수 api 연동.

### DIFF
--- a/src/pages/ArticlePage.jsx
+++ b/src/pages/ArticlePage.jsx
@@ -11,6 +11,8 @@ import ArticleInfo from '../components/article/ArticleInfo';
 import CommentButton from '../components/article/CommentButton';
 import { useAuth } from '../contexts/AuthContext';
 import MoveLogin from '../components/modal/MoveLogin';
+import { connectWebtoonSSE } from '../utils/sseConnect';
+import getOrCreateClientId from '../utils/getOrCreateClientId';
 
 function ArticlePage() {
   const { articleId } = useParams();
@@ -60,7 +62,6 @@ function ArticlePage() {
         setLikeCount(data1?.likeCount || 0);
         setViewCount(data1?.viewCount || 0);
         setCreatedAt(data1?.createdAt || '');
-        setActiveViewers(Math.floor(Math.random() * 30) + 10);
 
         // 웹툰 상세 정보 조회 (인증 불필요)
         const res2 = await DefaultAxios.get(`/api/v1/webtoons/${articleId}/details`);
@@ -77,6 +78,15 @@ function ArticlePage() {
     };
     fetchData();
   }, [articleId, isLoggedIn]);
+
+  // 실시간 시청자 수 SSE 연결
+  useEffect(() => {
+    const clientId = getOrCreateClientId();
+    const eventSource = connectWebtoonSSE(articleId, clientId, setActiveViewers);
+    return () => {
+      eventSource.close();
+    };
+  }, [articleId]);
 
   const handleBack = () => navigate(-1);
 

--- a/src/utils/sseConnect.jsx
+++ b/src/utils/sseConnect.jsx
@@ -34,4 +34,21 @@ function useSseNotifications(onNewNotification, onConnect) {
   }, [onNewNotification, onConnect]);
 }
 
+// 웹툰 실시간 시청자 수 SSE 연결 함수
+export function connectWebtoonSSE(webtoonId, clientId, onViewerCount) {
+  const url = `${import.meta.env.VITE_API_BASE_URL}/api/v1/sse/webtoon/connect?webtoonId=${webtoonId}&clientId=${clientId}`;
+  const eventSource = new window.EventSource(url);
+
+  eventSource.addEventListener('viewer-count', (event) => {
+    // "viewerCount: 1" 형태로 오므로 파싱
+    const count = Number(event.data.replace('viewerCount: ', ''));
+    onViewerCount(count);
+  });
+
+  eventSource.onerror = (err) => {
+    eventSource.close();
+  };
+  return eventSource;
+}
+
 export default useSseNotifications; 


### PR DESCRIPTION
## #️⃣연관된 이슈

#206 
## 📝작업 내용

실시간으로 웹툰 상세페이지 시청자 수를 알 수 있습니다. 

### 스크린샷

## 💬리뷰 요구사항(선택)


